### PR TITLE
feat: add wf to build package

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,6 +3,10 @@ name: PR Preview Build
 on:
     pull_request:
         types: [ opened, synchronize, reopened ]
+        paths:
+            - "src/**"
+            - "Cargo.toml"
+            - "Cargo.lock"
 
 permissions:
     contents: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,9 +26,6 @@ jobs:
                     - os: ubuntu-24.04-arm
                       target: aarch64-unknown-linux-gnu
                       artifact: mongo2pg-linux-aarch64
-                    - os: macos-13
-                      target: x86_64-apple-darwin
-                      artifact: mongo2pg-macos-x86_64
                     - os: macos-latest
                       target: aarch64-apple-darwin
                       artifact: mongo2pg-macos-aarch64

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,6 +1,7 @@
 name: PR Preview Build
 
 on:
+    workflow_dispatch:
     pull_request:
         types: [ opened, synchronize, reopened ]
         paths:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,149 @@
+name: PR Preview Build
+
+on:
+    pull_request:
+        types: [ opened, synchronize, reopened ]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    build:
+        name: Build – ${{ matrix.target }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - os: ubuntu-latest
+                      target: x86_64-unknown-linux-gnu
+                      artifact: mongo2pg-linux-x86_64
+                    - os: ubuntu-24.04-arm
+                      target: aarch64-unknown-linux-gnu
+                      artifact: mongo2pg-linux-aarch64
+                    - os: macos-13
+                      target: x86_64-apple-darwin
+                      artifact: mongo2pg-macos-x86_64
+                    - os: macos-latest
+                      target: aarch64-apple-darwin
+                      artifact: mongo2pg-macos-aarch64
+                    - os: windows-latest
+                      target: x86_64-pc-windows-msvc
+                      artifact: mongo2pg-windows-x86_64.exe
+                    - os: windows-11-arm
+                      target: aarch64-pc-windows-msvc
+                      artifact: mongo2pg-windows-aarch64.exe
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  targets: ${{ matrix.target }}
+
+            - name: Cache cargo registry
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      target
+                  key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock')
+                      }}
+                  restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+            - name: Build release binary
+              run: cargo build --release --target ${{ matrix.target }}
+
+            - name: Rename binary (Unix)
+              if: runner.os != 'Windows'
+              run: cp target/${{ matrix.target }}/release/mongo2pg ${{ matrix.artifact }}
+
+            - name: Rename binary (Windows)
+              if: runner.os == 'Windows'
+              run: cp target/${{ matrix.target }}/release/mongo2pg.exe ${{ matrix.artifact }}
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ matrix.artifact }}
+                  path: ${{ matrix.artifact }}
+                  retention-days: 7
+
+    preview-release:
+        name: Publish PR preview release
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  path: artifacts
+                  merge-multiple: true
+
+            - name: Delete previous preview release for this PR (if any)
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG="pr-${{ github.event.pull_request.number }}-preview"
+                  gh release delete "$TAG" --repo ${{ github.repository }} --yes 2>/dev/null || true
+                  git -c http.extraHeader="Authorization: Bearer $GH_TOKEN" \
+                    ls-remote --tags origin "$TAG" | grep -q . && \
+                    gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
+
+            - name: Create preview release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG="pr-${{ github.event.pull_request.number }}-preview"
+                  TITLE="PR #${{ github.event.pull_request.number }} preview – ${{ github.event.pull_request.title }}"
+                  gh release create "$TAG" artifacts/* \
+                    --repo ${{ github.repository }} \
+                    --title "$TITLE" \
+                    --notes "Preview build for PR #${{ github.event.pull_request.number }} (commit ${{ github.sha }}).
+                  This release is overwritten on every new push to the PR and deleted when the PR is closed." \
+                    --prerelease \
+                    --target ${{ github.sha }}
+
+            - name: Post download link as PR comment
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const tag = `pr-${context.payload.pull_request.number}-preview`;
+                      const releaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${tag}`;
+                      const body = `### Preview build ready\nBinaries for commit ${context.sha.slice(0,7)} are available at:\n${releaseUrl}\n\n> This release is updated on every push and deleted when the PR is closed.`;
+                      const comments = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.payload.pull_request.number,
+                      });
+                      const existing = comments.data.find(c => c.body.startsWith('### Preview build ready'));
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                          body,
+                        });
+                      }
+
+    cleanup:
+        name: Delete preview release on PR close
+        if: github.event.action == 'closed'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Delete preview release and tag
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG="pr-${{ github.event.pull_request.number }}-preview"
+                  gh release delete "$TAG" --repo ${{ github.repository }} --yes 2>/dev/null || true
+                  gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,3 +91,96 @@ mongo2pg "mongodb://localhost:27017" mydb.mycollection --no-values
 ```bash
 mongo2pg "mongodb://user:pass@host:27017/?authSource=admin&tls=true" mydb.mycollection
 ```
+
+---
+
+## Interpreting the output
+
+`mongo2pg` produces two kinds of output: **stats** printed to stderr and a **JSON schema** on stdout.
+
+### Stats (stderr)
+
+```
+Documents in collection : 45 231
+Documents sampled       : 1 000
+Width (top-level fields): 12
+Depth (max nesting)     : 4
+Branch (per level)      : L1:12  L2:8  L3:3  L4:1
+Top-level types         : _id:ObjectId  name:String  address:Object  …
+```
+
+| Stat | What it means |
+|---|---|
+| **Documents in collection** | Total documents in the collection (from MongoDB metadata, fast estimate). |
+| **Documents sampled** | How many documents were actually analysed. A higher number gives more reliable probabilities. |
+| **Width** | Number of distinct top-level field names. A large width (> 30–40) often signals a denormalised or poorly modelled collection. |
+| **Depth** | Maximum nesting level. Top-level fields are depth 1. An array containing an object with a field counts as depth 2. Depth > 3–4 suggests a heavily nested document model that may be hard to flatten into relations. |
+| **Branch (per level)** | Number of distinct fields at each nesting level. `L1:12  L2:8` means 12 fields at the top level and 8 fields inside nested objects one level down. A sharp drop-off (e.g. `L1:5  L2:50`) may indicate polymorphic sub-documents. |
+| **Top-level types** | The dominant BSON type for each top-level field, useful for a quick sanity check. |
+
+**What makes a good migration candidate?**
+
+A collection is typically easy to migrate to PostgreSQL when:
+
+- `Depth` is 1 or 2 (flat or only one level of nesting)
+- `Width` is stable and small (< 20 fields)
+- Per-level branch counts drop quickly (little nesting)
+- Field `probability` values are close to 1.0 (fields are present in most documents)
+
+Collections with high depth, high width, or many low-probability fields represent schema flexibility that is harder to map to a fixed relational model.
+
+---
+
+### JSON schema (stdout)
+
+The JSON output follows an extended JSON Schema dialect with three extra keywords:
+
+#### `x-bsonType`
+
+The original BSON type name (e.g. `"ObjectId"`, `"Date"`, `"Decimal128"`). Standard JSON Schema `type` only covers JSON primitives; `x-bsonType` preserves the MongoDB type fidelity.
+
+```json
+"_id": {
+  "x-bsonType": "ObjectId",
+  "x-metadata": { "count": 1000, "prob": 1.0 }
+}
+```
+
+#### `x-metadata`
+
+Per-field statistics:
+
+| Key | Description |
+|---|---|
+| `count` | Number of sampled documents in which this field was present. |
+| `prob` | `count / total_sampled` — probability the field exists in a document. A value of `1.0` means it was present in every sampled document; `0.5` means it was present in half. Fields with low probability are optional and will need a nullable column in PostgreSQL. |
+
+#### `x-sampleValues`
+
+A reservoir sample of up to 100 values (strings, binary, code) or 10 000 values (all other types) observed during sampling. Useful to spot unexpected values or confirm a field's real content before choosing a PostgreSQL column type.
+
+```json
+"status": {
+  "x-bsonType": "String",
+  "x-metadata": { "count": 998, "prob": 0.998 },
+  "x-sampleValues": ["active", "inactive", "pending", "active", "active"]
+}
+```
+
+#### `anyOf` — mixed-type fields
+
+When a field holds more than one BSON type across documents, the schema uses `anyOf` to list all observed types. Each branch has its own `x-bsonType` and `x-metadata`:
+
+```json
+"legacy_id": {
+  "anyOf": [
+    { "x-bsonType": "String",  "x-metadata": { "count": 750, "prob": 0.75 } },
+    { "x-bsonType": "Number",  "x-metadata": { "count": 200, "prob": 0.20 } },
+    { "x-bsonType": "Undefined", "x-metadata": { "count": 50, "prob": 0.05 } }
+  ]
+}
+```
+
+`Undefined` is a synthetic type injected for documents where the field was absent. Its `prob` is `1 - (presence_count / total_sampled)`.
+
+Mixed-type fields are the trickiest to migrate: you will need to decide whether to cast to a single type, split into multiple columns, or use a `jsonb` column in PostgreSQL.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,93 @@
+# Installation
+
+## Download a pre-built binary
+
+Go to the [Releases page](https://github.com/pmpetit/mongo2pg/releases) and download the archive that matches your platform:
+
+| Platform | File to download |
+|---|---|
+| Linux x86_64 | `mongo2pg-linux-x86_64` |
+| Linux arm64 | `mongo2pg-linux-aarch64` |
+| macOS Intel | `mongo2pg-macos-x86_64` |
+| macOS Apple Silicon | `mongo2pg-macos-aarch64` |
+| Windows x86_64 | `mongo2pg-windows-x86_64.exe` |
+| Windows arm64 | `mongo2pg-windows-aarch64.exe` |
+
+### Linux / macOS
+
+```bash
+# Replace <version> and <platform> with your values, e.g. v0.2.0 and linux-x86_64
+curl -L https://github.com/pmpetit/mongo2pg/releases/download/<version>/mongo2pg-<platform> \
+  -o mongo2pg
+chmod +x mongo2pg
+sudo mv mongo2pg /usr/local/bin/
+```
+
+### Windows
+
+Download the `.exe`, optionally rename it to `mongo2pg.exe`, and place it in a directory that is on your `PATH`.
+
+---
+
+## Build from source
+
+Requires [Rust](https://rustup.rs) (stable).
+
+```bash
+git clone https://github.com/pmpetit/mongo2pg
+cd mongo2pg
+cargo build --release
+# Binary at: ./target/release/mongo2pg
+```
+
+---
+
+## Usage examples
+
+### Infer the schema of a collection (1 000 documents sampled by default)
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection
+```
+
+### Sample a fixed number of documents
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection -n 5000
+```
+
+### Sample 10 % of the collection
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection -p 10
+```
+
+### Print statistics only (suppress JSON output)
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection --no-output
+```
+
+### Save the schema to a file
+
+```bash
+mongo2pg "mongodb://user:pass@host:27017" mydb.orders > orders-schema.json
+```
+
+### Use sequential scan instead of `$sample` (faster on small collections)
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection --no-sampling -n 2000
+```
+
+### Disable sample-value collection (smaller output)
+
+```bash
+mongo2pg "mongodb://localhost:27017" mydb.mycollection --no-values
+```
+
+### With authentication and TLS
+
+```bash
+mongo2pg "mongodb://user:pass@host:27017/?authSource=admin&tls=true" mydb.mycollection
+```


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically build and publish preview binaries for pull requests. The workflow builds the project for multiple operating systems and architectures, uploads the resulting binaries as a preview release, and manages the lifecycle of these preview releases as PRs are updated or closed.

**New PR preview build and release workflow:**

* Added `.github/workflows/pr-preview.yml` to automate building binaries for Linux, macOS, and Windows (both x86_64 and ARM architectures) on every pull request update, and upload them as artifacts.
* Implemented a step to create or update a GitHub release tagged for the PR, containing the latest preview binaries, and post a download link as a comment on the PR.
* Added logic to delete the preview release and tag automatically when the PR is closed, ensuring cleanup of temporary preview artifacts.