### PR TITLE
ci(wf): add release wf

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -78,6 +78,8 @@ jobs:
         name: Publish PR preview release
         needs: build
         runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/download-artifact@v4
               with:
@@ -96,16 +98,12 @@ jobs:
                   fi
 
             - name: Delete previous preview release (if any)
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   TAG="${{ steps.tag.outputs.value }}"
                   gh release delete "$TAG" --repo ${{ github.repository }} --yes 2>/dev/null || true
                   gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
 
             - name: Create preview release
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   TAG="${{ steps.tag.outputs.value }}"
                   TITLE="${{ steps.tag.outputs.title }}"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -84,35 +84,44 @@ jobs:
                   path: artifacts
                   merge-multiple: true
 
-            - name: Delete previous preview release for this PR (if any)
+            - name: Compute release tag
+              id: tag
+              run: |
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    echo "value=pr-${{ github.event.pull_request.number }}-preview" >> "$GITHUB_OUTPUT"
+                    echo "title=PR #${{ github.event.pull_request.number }} preview – ${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "value=manual-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+                    echo "title=Manual preview build (${{ github.sha }})" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Delete previous preview release (if any)
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TAG="pr-${{ github.event.pull_request.number }}-preview"
+                  TAG="${{ steps.tag.outputs.value }}"
                   gh release delete "$TAG" --repo ${{ github.repository }} --yes 2>/dev/null || true
-                  git -c http.extraHeader="Authorization: Bearer $GH_TOKEN" \
-                    ls-remote --tags origin "$TAG" | grep -q . && \
-                    gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
+                  gh api --method DELETE /repos/${{ github.repository }}/git/refs/tags/$TAG 2>/dev/null || true
 
             - name: Create preview release
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TAG="pr-${{ github.event.pull_request.number }}-preview"
-                  TITLE="PR #${{ github.event.pull_request.number }} preview – ${{ github.event.pull_request.title }}"
+                  TAG="${{ steps.tag.outputs.value }}"
+                  TITLE="${{ steps.tag.outputs.title }}"
                   gh release create "$TAG" artifacts/* \
                     --repo ${{ github.repository }} \
                     --title "$TITLE" \
-                    --notes "Preview build for PR #${{ github.event.pull_request.number }} (commit ${{ github.sha }}).
-                  This release is overwritten on every new push to the PR and deleted when the PR is closed." \
+                    --notes "Preview build for commit ${{ github.sha }}." \
                     --prerelease \
                     --target ${{ github.sha }}
 
             - name: Post download link as PR comment
+              if: github.event_name == 'pull_request'
               uses: actions/github-script@v7
               with:
                   script: |
-                      const tag = `pr-${context.payload.pull_request.number}-preview`;
+                      const tag = `${{ steps.tag.outputs.value }}`;
                       const releaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${tag}`;
                       const body = `### Preview build ready\nBinaries for commit ${context.sha.slice(0,7)} are available at:\n${releaseUrl}\n\n> This release is updated on every push and deleted when the PR is closed.`;
                       const comments = await github.rest.issues.listComments({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     push:
         tags:
             - "v*.*.*"
+    release:
+      types: [published]            
 
 permissions:
     contents: write

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,3 +184,203 @@ When a field holds more than one BSON type across documents, the schema uses `an
 `Undefined` is a synthetic type injected for documents where the field was absent. Its `prob` is `1 - (presence_count / total_sampled)`.
 
 Mixed-type fields are the trickiest to migrate: you will need to decide whether to cast to a single type, split into multiple columns, or use a `jsonb` column in PostgreSQL.
+
+---
+
+## Tutorial: run mongo2pg against MongoDB sample datasets
+
+This tutorial walks you through starting a local MongoDB instance with Docker, loading the official MongoDB sample datasets, and running `mongo2pg` against each collection.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- `mongo2pg` installed (see above)
+- `git` and `bash`
+
+---
+
+### Step 1 — Start MongoDB in Docker
+
+```bash
+docker run --name mongodb -d \
+  -p 2717:27017 \
+  -e MONGO_INITDB_ROOT_USERNAME=user \
+  -e MONGO_INITDB_ROOT_PASSWORD=pass \
+  mongodb/mongodb-community-server
+```
+
+Verify it is running:
+
+```bash
+docker ps | grep mongodb
+```
+
+---
+
+### Step 2 — Import the sample datasets
+
+Clone the sample dataset repository and run its import script:
+
+```bash
+git clone https://github.com/neelabalan/mongodb-sample-dataset
+cd mongodb-sample-dataset
+```
+
+The `start.sh` script uses `mongoimport` to load the data. It expects the MongoDB tools to be available. If you do not have `mongoimport` installed locally, run it inside the container:
+
+```bash
+# Copy the datasets into the container
+docker cp . mongodb:/tmp/mongodb-sample-dataset
+
+# Run the import from inside the container
+docker exec -it mongodb bash -c "
+  cd /tmp/mongodb-sample-dataset &&
+  bash start.sh 'mongodb://user:pass@localhost:27017/?authSource=admin'
+"
+```
+
+If `mongoimport` is available locally, you can pass the URI directly:
+
+```bash
+bash start.sh 'mongodb://user:pass@localhost:2717/?authSource=admin'
+```
+
+---
+
+### Step 3 — Run mongo2pg against each collection
+
+The URI for all commands below is:
+
+```
+mongodb://user:pass@localhost:2717/?authSource=admin
+```
+
+#### sample_airbnb
+
+```bash
+# 5 555 documents – deeply nested, good stress test
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_airbnb.listingsAndReviews --no-output
+```
+
+#### sample_analytics
+
+```bash
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_analytics.accounts --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_analytics.customers --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_analytics.transactions --no-output
+```
+
+#### sample_geospatial
+
+```bash
+# 11 095 documents – flat structure, good PostgreSQL candidate
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_geospatial.shipwrecks --no-output
+```
+
+#### sample_mflix
+
+```bash
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_mflix.comments --no-output
+
+# 23 539 movies – mixed types, arrays, nested objects
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_mflix.movies --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_mflix.theaters --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_mflix.users --no-output
+```
+
+#### sample_supplies
+
+```bash
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_supplies.sales --no-output
+```
+
+#### sample_training
+
+```bash
+# companies – 9 500 docs, very wide and nested
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.companies --no-output
+
+# grades – 100 000 docs, use --percent for a quick sample
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.grades -p 5 --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.inspections --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.routes --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.trips --no-output
+
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_training.zips --no-output
+```
+
+#### sample_weatherdata
+
+```bash
+# 10 000 documents – nested measurement objects
+mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
+  sample_weatherdata.data --no-output
+```
+
+---
+
+### Step 4 — Save schemas to files
+
+To keep the inferred schemas for later analysis:
+
+```bash
+URI="mongodb://user:pass@localhost:2717/?authSource=admin"
+mkdir -p schemas
+
+for ns in \
+  sample_airbnb.listingsAndReviews \
+  sample_analytics.accounts \
+  sample_analytics.customers \
+  sample_analytics.transactions \
+  sample_geospatial.shipwrecks \
+  sample_mflix.comments \
+  sample_mflix.movies \
+  sample_mflix.theaters \
+  sample_mflix.users \
+  sample_supplies.sales \
+  sample_training.companies \
+  sample_training.grades \
+  sample_training.inspections \
+  sample_training.routes \
+  sample_training.trips \
+  sample_training.zips \
+  sample_weatherdata.data
+do
+  filename=$(echo "$ns" | tr '.' '_')
+  echo "→ $ns"
+  mongo2pg "$URI" "$ns" 2>schemas/${filename}.stats.txt > schemas/${filename}.json
+done
+```
+
+Each collection produces two files: `<db>_<collection>.json` (the schema) and `<db>_<collection>.stats.txt` (the stats lines).
+
+---
+
+### Step 5 — Tear down
+
+```bash
+docker stop mongodb && docker rm mongodb
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,9 @@ Go to the [Releases page](https://github.com/pmpetit/mongo2pg/releases) and down
 
 ```bash
 # Replace <version> and <platform> with your values, e.g. v0.2.0 and linux-x86_64
-curl -L https://github.com/pmpetit/mongo2pg/releases/download/<version>/mongo2pg-<platform> \
+version="v0.2.0"
+platform="linux-x86_64"
+curl -fL "https://github.com/pmpetit/mongo2pg/releases/download/${version}/mongo2pg-${platform}" \
   -o mongo2pg
 chmod +x mongo2pg
 sudo mv mongo2pg /usr/local/bin/


### PR DESCRIPTION
This pull request introduces improvements to the release workflow and documentation, as well as adds a comprehensive tutorial for using `mongo2pg` with sample MongoDB datasets. The most notable changes are the addition of a step-by-step tutorial in the documentation, enhancements to the GitHub Actions workflows for preview and release builds, and a clearer installation example.

**Documentation improvements:**

* Added a detailed tutorial to `INSTALL.md` that guides users through running a local MongoDB instance with Docker, importing official MongoDB sample datasets, and using `mongo2pg` to analyze them. The tutorial includes prerequisites, setup, commands for each dataset, and cleanup steps.

* Improved the installation section in `INSTALL.md` with a safer, copy-paste-friendly example using shell variables for version and platform.

**GitHub Actions workflow enhancements:**

* Refactored the PR preview release workflow in `.github/workflows/pr-preview.yml` to compute release tags and titles dynamically, streamline deletion of previous preview releases, and improve environment variable handling.

* Updated `.github/workflows/release.yml` to also trigger on published releases, in addition to version tag pushes, ensuring releases are built and published consistently.