### PR TITLE
ci: remove macos13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
                     - os: ubuntu-24.04-arm
                       target: aarch64-unknown-linux-gnu
                       artifact: mongo2pg-linux-aarch64
-                    - os: macos-13
-                      target: x86_64-apple-darwin
-                      artifact: mongo2pg-macos-x86_64
+                    # - os: macos-13
+                    #   target: x86_64-apple-darwin
+                    #   artifact: mongo2pg-macos-x86_64
                     - os: macos-latest
                       target: aarch64-apple-darwin
                       artifact: mongo2pg-macos-aarch64


### PR DESCRIPTION
This pull request makes a small change to the release workflow configuration. The build step for the `x86_64-apple-darwin` (Intel Mac) target has been commented out and will no longer run as part of the release process. Only the ARM-based Mac build (`aarch64-apple-darwin`) will be produced for macOS.

- Commented out the job for building the `mongo2pg-macos-x86_64` (Intel Mac) artifact in `.github/workflows/release.yml`, so it is no longer included in the release workflow.