### PR TITLE
feat(to-pg): from json generate sql file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mongo2pg"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongo2pg"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Schema inference and conversion tool: MongoDB → JSON Schema variants"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -193,6 +193,14 @@ Mixed-type fields are the trickiest to migrate: you will need to decide whether 
 
 This tutorial walks you through starting a local MongoDB instance with Docker, loading the official MongoDB sample datasets, and running `mongo2pg` against each collection.
 
+The main principe is
+
+```bash
+# default output = raw CollectionSchema (needed by to-pg)
+mongo2pg "mongodb://..." db.col > schema.json
+mongo2pg to-pg schema.json > schema.sql
+```
+
 ### Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed and running
@@ -253,9 +261,11 @@ bash start.sh 'mongodb://user:pass@localhost:2717/?authSource=admin'
 
 The URI for all commands below is:
 
-```
+```bash
 mongodb://user:pass@localhost:2717/?authSource=admin
 ```
+
+The --no-output option removes the `json` output and keep only statistics on collection.
 
 #### sample_airbnb
 
@@ -346,9 +356,10 @@ mongo2pg "mongodb://user:pass@localhost:2717/?authSource=admin" \
 
 ### Step 4 — Save schemas to files
 
-To keep the inferred schemas for later analysis:
+To keep the inferred schemas for later analysis or create the postgres ddl.
 
 ```bash
+cd target
 URI="mongodb://user:pass@localhost:2717/?authSource=admin"
 mkdir -p schemas
 
@@ -381,7 +392,35 @@ Each collection produces two files: `<db>_<collection>.json` (the schema) and `<
 
 ---
 
-### Step 5 — Tear down
+### Step 5 — Generate pg DDL
+
+```bash
+for ns in \
+  sample_airbnb.listingsAndReviews \
+  sample_analytics_accounts \
+  sample_analytics_customers \
+  sample_analytics_transactions \
+  sample_geospatial_shipwrecks \
+  sample_mflix_comments \
+  sample_mflix_movies \
+  sample_mflix_theaters \
+  sample_mflix_users \
+  sample_supplies_sales \
+  sample_training_companies \
+  sample_training_grades \
+  sample_training_inspections \
+  sample_training_routes \
+  sample_training_trips \
+  sample_training_zips \
+  sample_weatherdata_data
+do
+  filename=$(echo "$ns" | tr '.' '_')
+  echo "→ $ns"
+  mongo2pg to-pg schemas/${filename}.json > schemas/${filename}.sql
+done
+```
+
+### Step 6 — Tear down
 
 ```bash
 docker stop mongodb && docker rm mongodb

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,7 +209,7 @@ mongo2pg to-pg schema.json > schema.sql
 
 ---
 
-### Step 1 — Start MongoDB in Docker
+### Step 1 — Start MongoDB community in Docker
 
 ```bash
 docker run --name mongodb -d \

--- a/README.md
+++ b/README.md
@@ -149,3 +149,7 @@ Tests cover:
 ## License
 
 Apache-2.0 – see [LICENSE](LICENSE).
+
+## Disclaimer
+
+This project is not affiliated with, endorsed by, or software from MongoDB, Inc. or the PostgreSQL Global Development Group. "MongoDB" and "PostgreSQL" are trademarks of their respective owners.

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -1,41 +1,63 @@
-//! `mongo2pg` CLI – Sample a MongoDB collection and infer its schema.
+//! `mongo2pg` CLI – Infer a MongoDB collection schema and convert it to PostgreSQL DDL.
 //!
-//! # Usage
+//! # Subcommands
+//!
+//! ## `mongo2pg infer` (default when no subcommand given)
 //! ```text
-//! mongo2pg <URI> <DB.COLLECTION> [OPTIONS]
-//!
-//! Options:
-//!   -n, --number <N>       Number of documents to sample [default: 1000]
-//!   -p, --percent <PCT>    Percentage of the collection to sample (mutually exclusive with -n)
-//!       --values           Collect sample values (default)
-//!       --no-values        Disable sample-value collection
-//!       --sampling         Use $sample aggregation (default)
-//!       --no-sampling      Use sequential find/limit instead of $sample
-//!       --no-output        Suppress schema output to stdout (useful with --stats)
+//! mongo2pg infer <URI> <DB.COLLECTION> [OPTIONS]
 //! ```
+//! Samples documents and writes the inferred schema JSON to stdout.
+//!
+//! ## `mongo2pg to-pg`
+//! ```text
+//! mongo2pg to-pg <SCHEMA_FILE> [--table <TABLE_NAME>]
+//! ```
+//! Converts a schema JSON file produced by `infer` into PostgreSQL DDL.
 
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
 use bson::doc;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use futures::TryStreamExt;
-use mongo2pg::analyzer::Analyzer;
+use mongo2pg::analyzer::{Analyzer, CollectionSchema};
 use mongo2pg::converters::to_expanded_schema;
 use mongo2pg::stats::format_stats;
+use mongo2pg::to_pg::schema_to_ddl;
 use mongodb::{options::ClientOptions, Client};
 
 // ──────────────────────────────────────────────────────────────────────────────
-// CLI argument definition
+// CLI definition
 // ──────────────────────────────────────────────────────────────────────────────
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(
     name = "mongo2pg",
-    about = "Sample a MongoDB collection and infer its JSON Schema",
-    version
+    about = "Infer a MongoDB collection schema and convert it to PostgreSQL DDL",
+    version,
+    // Allow bare `mongo2pg <URI> <NS>` without an explicit subcommand.
+    args_conflicts_with_subcommands = true
 )]
-struct Args {
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    // Flat infer args (used when no subcommand is given)
+    #[command(flatten)]
+    infer: Option<InferArgs>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Sample a MongoDB collection and infer its JSON Schema (default)
+    Infer(InferArgs),
+    /// Convert a schema JSON file to PostgreSQL DDL CREATE TABLE statements
+    ToPg(ToPgArgs),
+}
+
+#[derive(Parser, Debug)]
+struct InferArgs {
     /// MongoDB connection URI (e.g. mongodb://localhost:27017)
     uri: String,
 
@@ -71,9 +93,25 @@ struct Args {
     #[arg(long = "no-sampling", action = clap::ArgAction::SetTrue)]
     no_sampling: bool,
 
-    /// Suppress schema output to stdout (useful with --stats)
+    /// Suppress schema output to stdout
     #[arg(long = "no-output", action = clap::ArgAction::SetTrue)]
     no_output: bool,
+
+    /// Output the extended JSON Schema dialect (x-bsonType, x-metadata, x-sampleValues)
+    /// instead of the raw CollectionSchema JSON. Use this for human inspection;
+    /// the raw format is required by `mongo2pg to-pg`.
+    #[arg(long = "expanded", action = clap::ArgAction::SetTrue)]
+    expanded: bool,
+}
+
+#[derive(Parser, Debug)]
+struct ToPgArgs {
+    /// Path to a schema JSON file produced by `mongo2pg infer`
+    schema_file: PathBuf,
+
+    /// Root table name (defaults to the schema file stem)
+    #[arg(short = 't', long = "table")]
+    table: Option<String>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -82,15 +120,48 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let cli = Cli::parse();
 
+    match cli.command {
+        Some(Command::ToPg(args)) => run_to_pg(args),
+        Some(Command::Infer(args)) => run_infer(args).await,
+        None => run_infer(cli.infer.expect("clap ensures args are present")).await,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// `to-pg` subcommand
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn run_to_pg(args: ToPgArgs) -> Result<()> {
+    let content = std::fs::read_to_string(&args.schema_file)
+        .with_context(|| format!("Failed to read {}", args.schema_file.display()))?;
+
+    let schema: CollectionSchema = serde_json::from_str(&content)
+        .context("Failed to parse schema JSON – make sure the file was produced by mongo2pg")?;
+
+    let table_name = args.table.unwrap_or_else(|| {
+        args.schema_file
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("collection")
+            .to_owned()
+    });
+
+    println!("{}", schema_to_ddl(&schema, &table_name));
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// `infer` subcommand (also the default)
+// ──────────────────────────────────────────────────────────────────────────────
+
+async fn run_infer(args: InferArgs) -> Result<()> {
     let collect_values = !args.no_values;
     let use_sampling = !args.no_sampling;
 
-    // Parse namespace
     let (db_name, coll_name) = parse_namespace(&args.namespace)?;
 
-    // Connect to MongoDB
     let client_options = ClientOptions::parse(&args.uri)
         .await
         .context("Failed to parse MongoDB URI")?;
@@ -98,8 +169,6 @@ async fn main() -> Result<()> {
     let db = client.database(db_name);
     let collection = db.collection::<bson::Document>(coll_name);
 
-    // Resolve the number of documents to sample.
-    // When --percent is given we need the collection size first.
     let (sample_size, known_total) = if let Some(pct) = args.percent {
         if pct <= 0.0 || pct > 100.0 {
             return Err(anyhow!(
@@ -116,12 +185,9 @@ async fn main() -> Result<()> {
         (args.number, None)
     };
 
-    // Build analyzer
     let mut analyzer = Analyzer::new(collect_values);
 
-    // Sample documents
     if use_sampling {
-        // Use $sample aggregation
         let pipeline = vec![doc! { "$sample": { "size": sample_size as i64 } }];
         let mut cursor = collection
             .aggregate(pipeline)
@@ -131,7 +197,6 @@ async fn main() -> Result<()> {
             analyzer.process_document(&doc);
         }
     } else {
-        // Sequential find/limit
         let find_opts = mongodb::options::FindOptions::builder()
             .limit(sample_size as i64)
             .build();
@@ -147,7 +212,6 @@ async fn main() -> Result<()> {
 
     let schema = analyzer.finish();
 
-    // Print stats to stderr
     {
         let total_docs = if let Some(t) = known_total {
             t
@@ -165,11 +229,13 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Convert schema to expanded format and print as JSON
     let value = to_expanded_schema(&schema);
-
     if !args.no_output {
-        println!("{}", serde_json::to_string_pretty(&value)?);
+        if args.expanded {
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&schema)?);
+        }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@
 pub mod analyzer;
 pub mod converters;
 pub mod stats;
+pub mod to_pg;

--- a/src/to_pg.rs
+++ b/src/to_pg.rs
@@ -1,0 +1,918 @@
+//! PostgreSQL DDL generation from [`CollectionSchema`].
+//!
+//! Converts the internal schema representation produced by [`crate::analyzer::Analyzer`]
+//! into one or more `CREATE TABLE` statements:
+//!
+//! * Scalar fields → columns with the closest PostgreSQL type.
+//! * `Object` fields → separate 1:1 child table with a FK back to the parent.
+//! * `Array` of objects → child table with a FK (one row per array element).
+//! * `Array` of scalars → child table with a `value` column.
+//! * Mixed-type fields (Object/Array combined with scalars) → `JSONB`.
+//! * Hex-keyed map documents → child table with an extra `key TEXT NOT NULL` column.
+//!
+//! The public entry point is [`schema_to_ddl`].
+
+use indexmap::IndexMap;
+
+use crate::analyzer::{
+    CollectionSchema, FieldSchema, TypeSchema, TYPE_ARRAY, TYPE_BINARY, TYPE_BOOLEAN, TYPE_CODE,
+    TYPE_CODE_W_SCOPE, TYPE_DATE, TYPE_DBPOINTER, TYPE_DECIMAL128, TYPE_MAXKEY, TYPE_MINKEY,
+    TYPE_NULL, TYPE_NUMBER, TYPE_OBJECT, TYPE_OBJECTID, TYPE_REGEX, TYPE_STRING, TYPE_SYMBOL,
+    TYPE_TIMESTAMP, TYPE_UNDEFINED,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// BSON → PostgreSQL type mapping
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn bson_type_to_pg(t: &str) -> &'static str {
+    match t {
+        TYPE_STRING => "TEXT",
+        TYPE_NUMBER => "DOUBLE PRECISION",
+        TYPE_BOOLEAN => "BOOLEAN",
+        TYPE_DATE => "TIMESTAMP WITH TIME ZONE",
+        TYPE_DECIMAL128 => "NUMERIC",
+        TYPE_OBJECTID => "TEXT",
+        TYPE_BINARY => "BYTEA",
+        TYPE_TIMESTAMP => "BIGINT",
+        TYPE_REGEX | TYPE_SYMBOL | TYPE_CODE | TYPE_CODE_W_SCOPE | TYPE_DBPOINTER | TYPE_MAXKEY
+        | TYPE_MINKEY => "TEXT",
+        _ => "TEXT",
+    }
+}
+
+fn is_null_type(t: &str) -> bool {
+    t == TYPE_NULL || t == TYPE_UNDEFINED
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PostgreSQL identifier sanitization
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn is_pg_reserved(s: &str) -> bool {
+    matches!(
+        s,
+        "all"
+            | "analyse"
+            | "analyze"
+            | "and"
+            | "any"
+            | "array"
+            | "as"
+            | "asc"
+            | "asymmetric"
+            | "authorization"
+            | "binary"
+            | "both"
+            | "case"
+            | "cast"
+            | "check"
+            | "collate"
+            | "collation"
+            | "column"
+            | "concurrently"
+            | "constraint"
+            | "create"
+            | "cross"
+            | "current_catalog"
+            | "current_date"
+            | "current_role"
+            | "current_schema"
+            | "current_time"
+            | "current_timestamp"
+            | "current_user"
+            | "default"
+            | "deferrable"
+            | "desc"
+            | "distinct"
+            | "do"
+            | "else"
+            | "end"
+            | "except"
+            | "false"
+            | "fetch"
+            | "for"
+            | "foreign"
+            | "freeze"
+            | "from"
+            | "full"
+            | "grant"
+            | "group"
+            | "having"
+            | "ilike"
+            | "in"
+            | "initially"
+            | "inner"
+            | "intersect"
+            | "into"
+            | "is"
+            | "isnull"
+            | "join"
+            | "lateral"
+            | "leading"
+            | "left"
+            | "like"
+            | "limit"
+            | "localtime"
+            | "localtimestamp"
+            | "natural"
+            | "not"
+            | "notnull"
+            | "null"
+            | "offset"
+            | "on"
+            | "only"
+            | "or"
+            | "order"
+            | "outer"
+            | "overlaps"
+            | "placing"
+            | "primary"
+            | "references"
+            | "returning"
+            | "right"
+            | "select"
+            | "session_user"
+            | "similar"
+            | "some"
+            | "symmetric"
+            | "system_user"
+            | "table"
+            | "tablesample"
+            | "then"
+            | "to"
+            | "trailing"
+            | "true"
+            | "union"
+            | "unique"
+            | "user"
+            | "using"
+            | "variadic"
+            | "verbose"
+            | "when"
+            | "where"
+            | "window"
+            | "with"
+    )
+}
+
+/// Convert a MongoDB field name to a valid, lowercase PostgreSQL identifier.
+///
+/// Non-ASCII-alphanumeric characters are replaced with `_`. Names that start
+/// with a digit or clash with a PostgreSQL reserved word are prefixed with `_`.
+fn sanitize(name: &str) -> String {
+    let s: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if s.starts_with(|c: char| c.is_ascii_digit()) || is_pg_reserved(&s) {
+        format!("_{s}")
+    } else {
+        s
+    }
+}
+
+/// Return the plain scalar type to use for FK columns that reference serial PKs.
+fn fk_scalar_type(pg_type: &str) -> &str {
+    match pg_type {
+        "SERIAL" => "INTEGER",
+        "BIGSERIAL" => "BIGINT",
+        _ => pg_type,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Value-based type heuristics
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Returns `true` when every sampled value is a finite whole number.
+fn all_values_are_whole(values: &[serde_json::Value]) -> bool {
+    !values.is_empty()
+        && values.iter().all(|v| {
+            v.as_f64()
+                .map_or(false, |f| f.is_finite() && f == f.floor())
+        })
+}
+
+/// Returns a narrow integer PG type when every sampled value is a numeric string.
+fn numeric_string_pg_type(values: &[serde_json::Value]) -> Option<&'static str> {
+    if values.is_empty() {
+        return None;
+    }
+    if values
+        .iter()
+        .all(|v| v.as_str().map_or(false, |s| s.parse::<i64>().is_ok()))
+    {
+        let max = values
+            .iter()
+            .filter_map(|v| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+            .map(|n| n.unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        return Some(if max <= 2_147_483_647 {
+            "INTEGER"
+        } else {
+            "BIGINT"
+        });
+    }
+    if values
+        .iter()
+        .all(|v| v.as_str().map_or(false, |s| s.parse::<f64>().is_ok()))
+    {
+        return Some("DOUBLE PRECISION");
+    }
+    None
+}
+
+/// Returns `true` when every sampled Date value has a midnight UTC time component,
+/// making it a good candidate for `DATE` rather than `TIMESTAMP WITH TIME ZONE`.
+fn all_dates_are_date_only(values: &[serde_json::Value]) -> bool {
+    !values.is_empty()
+        && values.iter().all(|v| {
+            v.as_str().map_or(false, |s| {
+                let norm = s.replace(".000Z", "Z").replace(".000+00:00", "Z");
+                norm.ends_with("T00:00:00Z")
+            })
+        })
+}
+
+/// Returns `VARCHAR(n)` when the field name contains "code" and all sampled
+/// string values are shorter than 5 characters.
+fn varchar_for_code_field(col_name: &str, values: &[serde_json::Value]) -> Option<String> {
+    if !col_name.contains("code") || values.is_empty() {
+        return None;
+    }
+    let max_len = values
+        .iter()
+        .filter_map(|v| v.as_str().map(str::len))
+        .max()?;
+    if max_len < 5 {
+        Some(format!("VARCHAR({max_len})"))
+    } else {
+        None
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Type resolution
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Map a slice of non-null `(bson_type_name, TypeSchema)` pairs to a single PG type.
+fn resolve_scalar_pg_type(non_null: &[(&str, &TypeSchema)], col_name: &str) -> String {
+    if non_null.is_empty() {
+        return "TEXT".to_owned();
+    }
+
+    if non_null.len() == 1 {
+        let (name, ts) = non_null[0];
+        let values = ts.values.as_deref().unwrap_or(&[]);
+
+        if name == TYPE_NUMBER {
+            if all_values_are_whole(values) {
+                let max = values
+                    .iter()
+                    .filter_map(|v| v.as_f64())
+                    .map(|f| f.abs() as u64)
+                    .max()
+                    .unwrap_or(0);
+                return if max <= 2_147_483_647 {
+                    "INTEGER".to_owned()
+                } else {
+                    "BIGINT".to_owned()
+                };
+            }
+        }
+        if name == TYPE_DATE && all_dates_are_date_only(values) {
+            return "DATE".to_owned();
+        }
+        if name == TYPE_STRING {
+            if let Some(pg) = numeric_string_pg_type(values) {
+                return pg.to_owned();
+            }
+            if let Some(pg) = varchar_for_code_field(col_name, values) {
+                return pg;
+            }
+        }
+        return bson_type_to_pg(name).to_owned();
+    }
+
+    // Multiple non-null types – try to widen numeric types before falling back to TEXT.
+    // In the Rust schema, all numeric BSON types collapse to TYPE_NUMBER or TYPE_DECIMAL128.
+    let all_numeric = non_null
+        .iter()
+        .all(|(n, _)| *n == TYPE_NUMBER || *n == TYPE_DECIMAL128);
+    if all_numeric {
+        if non_null.iter().any(|(n, _)| *n == TYPE_DECIMAL128) {
+            return "NUMERIC".to_owned();
+        }
+        return "DOUBLE PRECISION".to_owned();
+    }
+
+    "TEXT".to_owned()
+}
+
+/// Infer the best PostgreSQL PK column type from the `_id` field's BSON types.
+fn pk_type_for_id(non_null: &[(&str, &TypeSchema)]) -> String {
+    if non_null.len() != 1 {
+        return "TEXT".to_owned();
+    }
+    let (name, ts) = non_null[0];
+    if name == TYPE_OBJECTID {
+        return "UUID".to_owned();
+    }
+    if name == TYPE_NUMBER {
+        let values = ts.values.as_deref().unwrap_or(&[]);
+        if all_values_are_whole(values) {
+            let max = values
+                .iter()
+                .filter_map(|v| v.as_f64())
+                .map(|f| f.abs() as u64)
+                .max()
+                .unwrap_or(0);
+            return if max <= 2_147_483_647 {
+                "SERIAL".to_owned()
+            } else {
+                "BIGSERIAL".to_owned()
+            };
+        }
+        return "BIGSERIAL".to_owned();
+    }
+    if name == TYPE_STRING {
+        let values = ts.values.as_deref().unwrap_or(&[]);
+        if !values.is_empty()
+            && values
+                .iter()
+                .all(|v| v.as_str().map_or(false, |s| s.parse::<i64>().is_ok()))
+        {
+            return "BIGSERIAL".to_owned();
+        }
+    }
+    "TEXT".to_owned()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal table / column structs
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct Column {
+    name: String,
+    pg_type: String,
+    nullable: bool,
+    primary_key: bool,
+}
+
+#[derive(Debug)]
+struct Table {
+    name: String,
+    columns: Vec<Column>,
+    child_tables: Vec<Table>,
+    /// `(fk_column_name, referenced_table_name, referenced_column_name)`
+    parent_ref: Option<(String, String, String)>,
+}
+
+impl Table {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            columns: Vec::new(),
+            child_tables: Vec::new(),
+            parent_ref: None,
+        }
+    }
+}
+
+/// Returns `(pk_column_name, pk_pg_type)` for a table, falling back to `("id", "TEXT")`.
+fn find_pk(table: &Table) -> (String, String) {
+    for col in &table.columns {
+        if col.primary_key {
+            return (col.name.clone(), col.pg_type.clone());
+        }
+    }
+    ("id".to_owned(), "TEXT".to_owned())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hex-keyed map document detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Returns `true` when `name` looks like a MongoDB map key (8+ lowercase hex chars).
+fn is_hex_keyed_name(name: &str) -> bool {
+    name.len() >= 8 && name.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+}
+
+/// For a map document (all sub-fields are hex-keyed), try to find uniform inner
+/// document fields. Returns the first non-empty inner `IndexMap` found, or `None`
+/// if there is no uniform inner structure (caller should fall back to JSONB).
+fn map_value_fields(doc_ts: &TypeSchema) -> Option<&IndexMap<String, FieldSchema>> {
+    let sub_fields = doc_ts.object.as_ref()?;
+    if sub_fields.is_empty() {
+        return None;
+    }
+    for sf in sub_fields.values() {
+        let nonnull: Vec<_> = sf
+            .types
+            .iter()
+            .filter(|(t, _)| !is_null_type(t.as_str()))
+            .collect();
+        if nonnull.len() == 1 && nonnull[0].0 == TYPE_OBJECT {
+            if let Some(inner) = &nonnull[0].1.object {
+                if !inner.is_empty() {
+                    return Some(inner);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Child table builders
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn add_child_table(
+    parent: &mut Table,
+    array_field_col: &str,
+    child_fields: &IndexMap<String, FieldSchema>,
+) {
+    let child_name = format!("{}_{}", parent.name, array_field_col);
+    let (pk_name, pk_type) = find_pk(parent);
+    let fk_col = format!("{}_id", parent.name);
+
+    let mut child = Table::new(child_name);
+    child.columns.push(Column {
+        name: "id".to_owned(),
+        pg_type: "BIGSERIAL".to_owned(),
+        nullable: false,
+        primary_key: true,
+    });
+    child.columns.push(Column {
+        name: fk_col.clone(),
+        pg_type: fk_scalar_type(&pk_type).to_owned(),
+        nullable: false,
+        primary_key: false,
+    });
+    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    process_fields(&mut child, child_fields, "", true);
+    parent.child_tables.push(child);
+}
+
+fn add_scalar_array_table(
+    parent: &mut Table,
+    array_field_col: &str,
+    scalar_types: &[(&str, &TypeSchema)],
+) {
+    let child_name = format!("{}_{}", parent.name, array_field_col);
+    let (pk_name, pk_type) = find_pk(parent);
+    let fk_col = format!("{}_id", parent.name);
+
+    let mut child = Table::new(child_name);
+    child.columns.push(Column {
+        name: "id".to_owned(),
+        pg_type: "BIGSERIAL".to_owned(),
+        nullable: false,
+        primary_key: true,
+    });
+    child.columns.push(Column {
+        name: fk_col.clone(),
+        pg_type: fk_scalar_type(&pk_type).to_owned(),
+        nullable: false,
+        primary_key: false,
+    });
+    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    let non_null: Vec<(&str, &TypeSchema)> = scalar_types
+        .iter()
+        .filter(|(t, _)| !is_null_type(t))
+        .copied()
+        .collect();
+    let value_type = if non_null.is_empty() {
+        "TEXT".to_owned()
+    } else {
+        resolve_scalar_pg_type(&non_null, "value")
+    };
+    child.columns.push(Column {
+        name: "value".to_owned(),
+        pg_type: value_type,
+        nullable: false,
+        primary_key: false,
+    });
+
+    parent.child_tables.push(child);
+}
+
+/// Create a 1:1 child table for an embedded document field.
+fn add_doc_table(
+    parent: &mut Table,
+    doc_field_col: &str,
+    doc_fields: &IndexMap<String, FieldSchema>,
+) {
+    let child_name = format!("{}_{}", parent.name, doc_field_col);
+    let (pk_name, pk_type) = find_pk(parent);
+    let fk_col = format!("{}_id", parent.name);
+
+    let mut child = Table::new(child_name);
+    child.columns.push(Column {
+        name: "id".to_owned(),
+        pg_type: "BIGSERIAL".to_owned(),
+        nullable: false,
+        primary_key: true,
+    });
+    child.columns.push(Column {
+        name: fk_col.clone(),
+        pg_type: fk_scalar_type(&pk_type).to_owned(),
+        nullable: false,
+        primary_key: false,
+    });
+    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    process_fields(&mut child, doc_fields, "", false);
+    parent.child_tables.push(child);
+}
+
+/// Create a child table for a MongoDB map document (dynamic hex-keyed sub-fields).
+/// An extra `key TEXT NOT NULL` column holds the original dynamic key.
+fn add_map_table(
+    parent: &mut Table,
+    map_field_col: &str,
+    value_fields: &IndexMap<String, FieldSchema>,
+) {
+    let child_name = format!("{}_{}", parent.name, map_field_col);
+    let (pk_name, pk_type) = find_pk(parent);
+    let fk_col = format!("{}_id", parent.name);
+
+    let mut child = Table::new(child_name);
+    child.columns.push(Column {
+        name: "id".to_owned(),
+        pg_type: "BIGSERIAL".to_owned(),
+        nullable: false,
+        primary_key: true,
+    });
+    child.columns.push(Column {
+        name: fk_col.clone(),
+        pg_type: fk_scalar_type(&pk_type).to_owned(),
+        nullable: false,
+        primary_key: false,
+    });
+    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+    child.columns.push(Column {
+        name: "key".to_owned(),
+        pg_type: "TEXT".to_owned(),
+        nullable: false,
+        primary_key: false,
+    });
+
+    process_fields(&mut child, value_fields, "", false);
+    parent.child_tables.push(child);
+}
+
+fn handle_array_field(
+    table: &mut Table,
+    col_name: &str,
+    items_field: &FieldSchema,
+    nullable: bool,
+) {
+    let non_null_items: Vec<(&str, &TypeSchema)> = items_field
+        .types
+        .iter()
+        .filter(|(t, _)| !is_null_type(t.as_str()))
+        .map(|(t, ts)| (t.as_str(), ts))
+        .collect();
+
+    if let Some((_, doc_ts)) = non_null_items.iter().find(|(t, _)| *t == TYPE_OBJECT) {
+        // Array of documents → child table (one row per array element)
+        if let Some(child_fields) = &doc_ts.object {
+            let cf = child_fields.clone();
+            add_child_table(table, col_name, &cf);
+        } else {
+            // Object type but no inner fields schema
+            table.columns.push(Column {
+                name: col_name.to_owned(),
+                pg_type: "JSONB".to_owned(),
+                nullable,
+                primary_key: false,
+            });
+        }
+    } else {
+        // Array of scalars → child table with `value` column
+        add_scalar_array_table(table, col_name, &non_null_items);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Main recursive field processor
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn process_fields(
+    table: &mut Table,
+    fields: &IndexMap<String, FieldSchema>,
+    col_prefix: &str,
+    mark_pk: bool,
+) {
+    for (raw_name, field) in fields {
+        let col_name = sanitize(&format!("{col_prefix}{raw_name}"));
+
+        let non_null: Vec<(&str, &TypeSchema)> = field
+            .types
+            .iter()
+            .filter(|(t, _)| !is_null_type(t.as_str()))
+            .map(|(t, ts)| (t.as_str(), ts))
+            .collect();
+
+        // A field is nullable when it has a Null/Undefined type OR when it is
+        // absent in some documents (prob < 1.0).
+        let nullable = non_null.len() < field.types.len() || field.prop_in_object < 1.0;
+
+        if non_null.is_empty() {
+            // Field is always null/undefined – omit from DDL.
+            continue;
+        }
+
+        // ── Single pure Object ────────────────────────────────────────────────
+        if non_null.len() == 1 && non_null[0].0 == TYPE_OBJECT {
+            let ts = non_null[0].1;
+            let is_hex = ts.object.as_ref().map_or(false, |sf| {
+                !sf.is_empty() && sf.keys().all(|k| is_hex_keyed_name(k))
+            });
+
+            if is_hex {
+                // Map document (dynamic hex keys)
+                let value_fields = map_value_fields(ts).map(|vf| vf.clone());
+                if let Some(vf) = value_fields {
+                    add_map_table(table, &col_name, &vf);
+                } else {
+                    table.columns.push(Column {
+                        name: col_name,
+                        pg_type: "JSONB".to_owned(),
+                        nullable,
+                        primary_key: false,
+                    });
+                }
+            } else if let Some(sub_fields) = &ts.object {
+                let sf = sub_fields.clone();
+                add_doc_table(table, &col_name, &sf);
+            } else {
+                // Object type but no inner field schema (empty document)
+                table.columns.push(Column {
+                    name: col_name,
+                    pg_type: "JSONB".to_owned(),
+                    nullable,
+                    primary_key: false,
+                });
+            }
+            continue;
+        }
+
+        // ── Single pure Array ─────────────────────────────────────────────────
+        if non_null.len() == 1 && non_null[0].0 == TYPE_ARRAY {
+            let ts = non_null[0].1;
+            if let Some(items_field) = &ts.array {
+                let items = *items_field.clone();
+                handle_array_field(table, &col_name, &items, nullable);
+            } else {
+                // Array with no items schema → JSONB
+                table.columns.push(Column {
+                    name: col_name,
+                    pg_type: "JSONB".to_owned(),
+                    nullable,
+                    primary_key: false,
+                });
+            }
+            continue;
+        }
+
+        // ── Object or Array mixed with other types → JSONB ────────────────────
+        if non_null
+            .iter()
+            .any(|(t, _)| *t == TYPE_OBJECT || *t == TYPE_ARRAY)
+        {
+            table.columns.push(Column {
+                name: col_name,
+                pg_type: "JSONB".to_owned(),
+                nullable,
+                primary_key: false,
+            });
+            continue;
+        }
+
+        // ── Scalar field(s) ───────────────────────────────────────────────────
+        let is_pk = raw_name == "_id" && col_prefix.is_empty() && mark_pk;
+        let pg_type = if is_pk {
+            pk_type_for_id(&non_null)
+        } else {
+            resolve_scalar_pg_type(&non_null, &col_name)
+        };
+
+        if is_pk {
+            if table.columns.iter().any(|c| c.primary_key) {
+                // A surrogate PK was already added (e.g. from add_child_table).
+                continue;
+            }
+            table.columns.push(Column {
+                name: "id".to_owned(),
+                pg_type,
+                nullable: false,
+                primary_key: true,
+            });
+        } else {
+            // Guard against a literal field named "id" clashing with a surrogate PK.
+            let final_name = if col_name == "id" && table.columns.iter().any(|c| c.name == "id") {
+                "field_id".to_owned()
+            } else {
+                col_name
+            };
+            table.columns.push(Column {
+                name: final_name,
+                pg_type,
+                nullable,
+                primary_key: false,
+            });
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tree traversal and DDL rendering
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn collect_tables(root: &Table) -> Vec<&Table> {
+    let mut result: Vec<&Table> = Vec::new();
+    let mut queue: Vec<&Table> = vec![root];
+    while !queue.is_empty() {
+        let current = queue.remove(0);
+        result.push(current);
+        for child in &current.child_tables {
+            queue.push(child);
+        }
+    }
+    result
+}
+
+fn render_column(col: &Column) -> String {
+    let constraint = if col.primary_key {
+        " PRIMARY KEY"
+    } else if !col.nullable {
+        " NOT NULL"
+    } else {
+        ""
+    };
+    format!("    {}{} {}{constraint}", col.name, "", col.pg_type)
+        .trim_end()
+        .to_owned()
+}
+
+fn render_table(table: &Table) -> String {
+    let mut defs: Vec<String> = table.columns.iter().map(render_column).collect();
+    if let Some((fk_col, ref_table, ref_col)) = &table.parent_ref {
+        defs.push(format!(
+            "    FOREIGN KEY ({fk_col}) REFERENCES {ref_table} ({ref_col})"
+        ));
+    }
+    let body = defs.join(",\n");
+    format!("CREATE TABLE {} (\n{}\n);", table.name, body)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Convert a [`CollectionSchema`] to PostgreSQL DDL `CREATE TABLE` statements.
+///
+/// Nested objects become 1:1 child tables. Arrays of documents become 1:N child
+/// tables. Arrays of scalars become child tables with a `value` column.
+/// Mixed-type or empty-array fields fall back to `JSONB`.
+///
+/// Summary statistics (table and column counts) are printed to **stderr**.
+///
+/// # Arguments
+/// * `schema` – The schema produced by [`crate::analyzer::Analyzer::finish`].
+/// * `table_name` – Base name for the root table (will be sanitised).
+///
+/// # Returns
+/// A string containing one or more `CREATE TABLE` statements separated by blank lines.
+pub fn schema_to_ddl(schema: &CollectionSchema, table_name: &str) -> String {
+    let mut root = Table::new(sanitize(table_name));
+    process_fields(&mut root, &schema.object, "", true);
+
+    let tables = collect_tables(&root);
+    let total_cols: usize = tables.iter().map(|t| t.columns.len()).sum();
+
+    eprintln!("tables : {}", tables.len());
+    eprintln!("columns: {total_cols}");
+
+    tables
+        .iter()
+        .map(|t| render_table(t))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::Analyzer;
+    use bson::doc;
+
+    fn analyze(docs: &[bson::Document]) -> CollectionSchema {
+        let mut a = Analyzer::new(true);
+        for d in docs {
+            a.process_document(d);
+        }
+        a.finish()
+    }
+
+    #[test]
+    fn test_flat_collection() {
+        let docs = vec![
+            doc! { "_id": 1_i32, "name": "Alice", "score": 99_i32 },
+            doc! { "_id": 2_i32, "name": "Bob",   "score": 88_i32 },
+        ];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "users");
+        assert!(ddl.contains("CREATE TABLE users ("), "root table missing");
+        assert!(ddl.contains("name TEXT"), "name column missing");
+        assert!(ddl.contains("score"), "score column missing");
+    }
+
+    #[test]
+    fn test_nullable_field() {
+        let docs = vec![
+            doc! { "_id": 1_i32, "opt": "present" },
+            doc! { "_id": 2_i32 },
+        ];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "t");
+        // opt must not be NOT NULL
+        assert!(
+            !ddl.contains("opt TEXT NOT NULL"),
+            "optional field must not have NOT NULL"
+        );
+    }
+
+    #[test]
+    fn test_objectid_pk_becomes_uuid() {
+        let docs = vec![doc! { "_id": bson::oid::ObjectId::new(), "x": 1_i32 }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "t");
+        assert!(
+            ddl.contains("id UUID PRIMARY KEY"),
+            "ObjectId PK should become UUID"
+        );
+    }
+
+    #[test]
+    fn test_nested_object_creates_child_table() {
+        let docs = vec![doc! { "_id": 1_i32, "addr": { "city": "Paris" } }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "orders");
+        assert!(
+            ddl.contains("CREATE TABLE orders_addr ("),
+            "child table for addr missing"
+        );
+        assert!(ddl.contains("FOREIGN KEY"), "FK constraint missing");
+    }
+
+    #[test]
+    fn test_array_of_scalars_creates_child_table() {
+        let docs = vec![doc! { "_id": 1_i32, "tags": ["rust", "mongodb"] }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "posts");
+        assert!(
+            ddl.contains("CREATE TABLE posts_tags ("),
+            "scalar array child table missing"
+        );
+        assert!(ddl.contains("value TEXT"), "value column missing");
+    }
+
+    #[test]
+    fn test_reserved_word_prefixed() {
+        let docs = vec![doc! { "_id": 1_i32, "order": "asc" }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "t");
+        assert!(
+            ddl.contains("_order"),
+            "reserved word 'order' should be prefixed with _"
+        );
+    }
+
+    #[test]
+    fn test_sanitize() {
+        assert_eq!(sanitize("myField"), "myfield");
+        assert_eq!(sanitize("my-field"), "my_field");
+        assert_eq!(sanitize("123abc"), "_123abc");
+        assert_eq!(sanitize("order"), "_order");
+        assert_eq!(sanitize("_id"), "_id");
+    }
+}


### PR DESCRIPTION
fix: #8 

This pull request introduces a new subcommand-based CLI structure to the `mongo2pg` tool, making it easier to use and extending its capabilities. The main highlights are the addition of a `to-pg` subcommand for converting inferred schema JSON files to PostgreSQL DDL, improvements to the documentation, and enhancements to the CLI argument handling. These changes improve usability and clarify the workflow for migrating MongoDB collections to PostgreSQL.

### CLI and Workflow Improvements

* Refactored the CLI to use subcommands: `infer` (default, for schema inference) and `to-pg` (for converting schema JSON to PostgreSQL DDL). The CLI now uses `clap`'s subcommand support, with clear argument structures for each mode. (`src/bin/mongo2pg.rs`, [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL1-R60) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL74-R114) [[3]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL85-L102)
* Added the `to-pg` subcommand, which reads a schema JSON file and outputs PostgreSQL `CREATE TABLE` statements. (`src/bin/mongo2pg.rs`, [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL85-L102) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL168-R238); `src/lib.rs`, [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R13)
* Improved argument parsing for the `infer` command, including support for an `--expanded` flag to output an extended JSON Schema dialect for human inspection. (`src/bin/mongo2pg.rs`, [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL74-R114) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL168-R238)

### Documentation Updates

* Updated `INSTALL.md` to document the new subcommand-based workflow, including example commands for inferring schemas and generating PostgreSQL DDL. Expanded the tutorial to clarify the main usage principles and added new sections for DDL generation. (`INSTALL.md`, [[1]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0R196-R203) [[2]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L256-R269) [[3]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L349-R362) [[4]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L384-R423)

### Other Changes

* Bumped the package version from `0.1.0` to `0.2.0` in `Cargo.toml` to reflect the new features. (`Cargo.toml`, [Cargo.tomlL3-R3](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3))
* Minor code cleanups and improved inline documentation for the CLI and its subcommands. (`src/bin/mongo2pg.rs`, [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL1-R60) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL119-L124) [[3]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL134) [[4]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL150)

These changes make the tool more modular and user-friendly, and better document the recommended migration workflow.