### PR TITLE
feat(export): add export command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +495,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1012,6 +1037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1082,7 @@ dependencies = [
  "bson",
  "chrono",
  "clap",
+ "flate2",
  "futures",
  "indexmap",
  "mongodb",
@@ -1576,6 +1612,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 anyhow = "1"
 futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
+flate2 = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Just as tool exist to migrate from relational databases to document stores, a to
 - **Expanded output** – extended JSON Schema with `x-bsonType`, `x-metadata`, `x-sampleValues`
 - **Stats** – width / depth / branch counts printed to stderr with `--stats`
 - **Reservoir sampling** of field values (100 samples for strings/binary/code, 10 000 otherwise)
-- **Output renderers**: JSON (default), YAML, ASCII 
+- **Output renderers**: JSON (default), YAML, ASCII
 
 ---
 
@@ -55,9 +55,10 @@ Quick start:
 mongo2pg init --project-base /app/migration --project-name retail \
   --uri "mongodb://user:pass@localhost:27017"
 
-# 2. Infer schemas, generate SQL, generate reports
+# 2. Infer schemas, generate SQL, export data, generate reports
 mongo2pg infer  -c /app/migration/retail/config/retail.conf
 mongo2pg to-pg  -c /app/migration/retail/config/retail.conf
+mongo2pg export -c /app/migration/retail/config/retail.conf
 mongo2pg report -c /app/migration/retail/config/retail.conf
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -545,6 +545,53 @@ Reads `source/collections/<name>/<name>.json` and writes `schema/tables/<name>.s
 
 ---
 
+## `export` – export MongoDB data to gzipped CSV files
+
+```
+mongo2pg export [COLLECTION] [OPTIONS]
+```
+
+For each collection, reads the corresponding `schema/tables/<name>.sql` to understand
+the table hierarchy, then streams **all documents** from MongoDB and writes one
+`.csv.gz` file per SQL table into `data/<collection_name>/`.
+
+Nested arrays and objects are expanded across child tables exactly as `to-pg` modelled
+them, so the CSV files can be loaded directly into PostgreSQL with `\COPY`.
+
+**Arguments**
+
+| Argument | Description |
+|---|---|
+| `[COLLECTION]` | Optional collection name; omit to export all collections found in `schema/tables/` |
+
+**Options**
+
+| Flag | Description |
+|---|---|
+| `-c, --config <FILE>` | Project config file – derives URI, database name, `schema/tables/` and `data/` paths |
+| `-o, --output-dir <DIR>` | Override the output directory for CSV files (default: `<project>/data/`) |
+
+**Output layout**
+
+```
+data/
+└── orders/
+    ├── orders.csv.gz
+    ├── orders_products.csv.gz
+    ├── orders_products_image.csv.gz
+    ├── orders_products_price.csv.gz
+    └── orders_status_history.csv.gz
+```
+
+**Loading into PostgreSQL**
+
+```sql
+\COPY orders FROM PROGRAM 'gunzip -c orders.csv.gz' CSV HEADER;
+\COPY orders_products FROM PROGRAM 'gunzip -c orders_products.csv.gz' CSV HEADER;
+```
+
+---
+
 ## `report` – generate HTML reports
 
 ```
@@ -586,7 +633,10 @@ mongo2pg infer -c /app/migration/retail/config/retail.conf
 # 4. Generate PostgreSQL DDL
 mongo2pg to-pg -c /app/migration/retail/config/retail.conf
 
-# 5. Generate HTML reports + ERD diagram
+# 5. Export data to gzipped CSV files
+mongo2pg export -c /app/migration/retail/config/retail.conf
+
+# 6. Generate HTML reports + ERD diagram
 mongo2pg report -c /app/migration/retail/config/retail.conf
 ```
 
@@ -612,4 +662,13 @@ mongo2pg to-pg -c config/retail.conf products
 
 # Generate reports
 mongo2pg report -c config/retail.conf
+
+# Export all collections to gzipped CSV
+mongo2pg export -c config/retail.conf
+
+# Export a single collection
+mongo2pg export -c config/retail.conf orders
+
+# Export to a custom output directory
+mongo2pg export -c config/retail.conf -o /tmp/csv
 ```

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -23,6 +23,7 @@ use clap::{Parser, Subcommand};
 use futures::TryStreamExt;
 use indexmap::IndexMap;
 use mongo2pg::analyzer::{Analyzer, CollectionSchema};
+use mongo2pg::export::export_collection;
 use mongo2pg::report::{collect_rows, render_html};
 use mongo2pg::schema_diagram::{load_tables, render_schema_html};
 use mongo2pg::stats::{format_stats, stats_to_yaml};
@@ -60,6 +61,8 @@ enum Command {
     Init(InitArgs),
     /// Generate an HTML migration report from inferred collection stats
     Report(ReportArgs),
+    /// Export MongoDB data to gzipped CSV files (one per SQL table)
+    Export(ExportArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -166,6 +169,20 @@ struct SchemaArgs {
     output: Option<PathBuf>,
 }
 
+#[derive(Parser, Debug)]
+struct ExportArgs {
+    /// Optional collection name; if omitted all collections in schema/tables/ are exported
+    collection: Option<String>,
+
+    /// Path to the project config file (.conf) – derives URI, db, schema/tables and data/ paths
+    #[arg(short = 'c', long = "config")]
+    config: Option<PathBuf>,
+
+    /// Override the output directory for CSV files (default: <project>/data/)
+    #[arg(short = 'o', long = "output-dir")]
+    output_dir: Option<PathBuf>,
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Entry point
 // ──────────────────────────────────────────────────────────────────────────────
@@ -178,6 +195,7 @@ async fn main() -> Result<()> {
         Some(Command::Init(args)) => run_init(args),
         Some(Command::ToPg(args)) => run_to_pg(args),
         Some(Command::Report(args)) => run_report(args),
+        Some(Command::Export(args)) => run_export(args).await,
         Some(Command::Infer(args)) => run_infer(args).await,
         None => run_infer(cli.infer.expect("clap ensures args are present")).await,
     }
@@ -468,6 +486,71 @@ fn run_init(args: InitArgs) -> Result<()> {
         println!("  {}", dir.display());
     }
     println!("  {}", conf_path.display());
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// `export` subcommand
+// ──────────────────────────────────────────────────────────────────────────────
+
+async fn run_export(args: ExportArgs) -> Result<()> {
+    let conf = args
+        .config
+        .as_ref()
+        .ok_or_else(|| anyhow!("Provide -c <config>"))?;
+
+    let (base_dir, project_dir, conf_uri, conf_ns) = read_conf(conf)?;
+    let uri = conf_uri.ok_or_else(|| anyhow!("No URI in config file"))?;
+    let db_name = conf_ns.ok_or_else(|| anyhow!("No NAMESPACE in config file"))?;
+
+    let project_root = base_dir.join(&project_dir);
+    let tables_dir = project_root.join("schema").join("tables");
+    let data_dir = args
+        .output_dir
+        .clone()
+        .unwrap_or_else(|| project_root.join("data"));
+
+    let client_options = ClientOptions::parse(&uri)
+        .await
+        .context("Failed to parse MongoDB URI")?;
+    let client = Client::with_options(client_options).context("Failed to create MongoDB client")?;
+
+    // Determine which collections to export
+    let collections: Vec<String> = if let Some(name) = args.collection.clone() {
+        vec![name]
+    } else {
+        let mut names: Vec<String> = std::fs::read_dir(&tables_dir)
+            .with_context(|| format!("Cannot read {}", tables_dir.display()))?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sql"))
+            .filter_map(|e| {
+                e.path()
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_owned())
+            })
+            .collect();
+        names.sort();
+        names
+    };
+
+    if collections.is_empty() {
+        eprintln!("No SQL schema files found in {}", tables_dir.display());
+        return Ok(());
+    }
+
+    for coll_name in &collections {
+        eprintln!("[{db_name}.{coll_name}]");
+        match export_collection(&client, &db_name, coll_name, &tables_dir, &data_dir).await {
+            Ok(files) => {
+                for f in files {
+                    println!("{f}");
+                }
+            }
+            Err(e) => eprintln!("  warning: {e}"),
+        }
+    }
+
     Ok(())
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,528 @@
+//! Export MongoDB collection data to gzipped CSV files.
+//!
+//! For each collection, reads the generated SQL DDL from `schema/tables/<name>.sql`
+//! to determine the table structure, then streams all documents from MongoDB and
+//! writes one gzipped CSV file per SQL table into `data/<name>/`.
+//!
+//! Nested arrays and objects are expanded across child tables exactly as
+//! `to_pg` generated them, so the CSV files can be loaded directly into
+//! PostgreSQL with `\COPY`.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use bson::Bson;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use futures::TryStreamExt;
+use mongodb::Client;
+
+use crate::schema_diagram::{parse_sql, Table as SqlTable};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sanitize  (mirrors to_pg::sanitize so we can reverse-map SQL columns → Mongo fields)
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn is_pg_reserved(s: &str) -> bool {
+    matches!(
+        s,
+        "all"
+            | "analyse"
+            | "analyze"
+            | "and"
+            | "any"
+            | "array"
+            | "as"
+            | "asc"
+            | "asymmetric"
+            | "authorization"
+            | "binary"
+            | "both"
+            | "case"
+            | "cast"
+            | "check"
+            | "collate"
+            | "collation"
+            | "column"
+            | "concurrently"
+            | "constraint"
+            | "create"
+            | "cross"
+            | "current_catalog"
+            | "current_date"
+            | "current_role"
+            | "current_schema"
+            | "current_time"
+            | "current_timestamp"
+            | "current_user"
+            | "default"
+            | "deferrable"
+            | "desc"
+            | "distinct"
+            | "do"
+            | "else"
+            | "end"
+            | "except"
+            | "false"
+            | "fetch"
+            | "for"
+            | "foreign"
+            | "freeze"
+            | "from"
+            | "full"
+            | "grant"
+            | "group"
+            | "having"
+            | "ilike"
+            | "in"
+            | "initially"
+            | "inner"
+            | "intersect"
+            | "into"
+            | "is"
+            | "isnull"
+            | "join"
+            | "lateral"
+            | "leading"
+            | "left"
+            | "like"
+            | "limit"
+            | "localtime"
+            | "localtimestamp"
+            | "natural"
+            | "not"
+            | "notnull"
+            | "null"
+            | "offset"
+            | "on"
+            | "only"
+            | "or"
+            | "order"
+            | "outer"
+            | "overlaps"
+            | "placing"
+            | "primary"
+            | "references"
+            | "returning"
+            | "right"
+            | "select"
+            | "session_user"
+            | "similar"
+            | "some"
+            | "symmetric"
+            | "system_user"
+            | "table"
+            | "tablesample"
+            | "then"
+            | "to"
+            | "trailing"
+            | "true"
+            | "union"
+            | "unique"
+            | "user"
+            | "using"
+            | "variadic"
+            | "verbose"
+            | "when"
+            | "where"
+            | "window"
+            | "with"
+    )
+}
+
+fn sanitize(name: &str) -> String {
+    let s: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if s.starts_with(|c: char| c.is_ascii_digit()) || is_pg_reserved(&s) {
+        format!("_{s}")
+    } else {
+        s
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// BSON → CSV string
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn bson_to_string(val: &Bson) -> String {
+    match val {
+        Bson::ObjectId(oid) => oid.to_hex(),
+        Bson::String(s) => s.clone(),
+        Bson::Int32(n) => n.to_string(),
+        Bson::Int64(n) => n.to_string(),
+        Bson::Double(d) => d.to_string(),
+        Bson::Boolean(b) => b.to_string(),
+        Bson::DateTime(dt) => format_millis(dt.timestamp_millis()),
+        Bson::Decimal128(d) => d.to_string(),
+        Bson::Timestamp(ts) => ts.time.to_string(),
+        Bson::Null | Bson::Undefined => String::new(),
+        // For complex / uncommon types fall back to BSON extended-JSON representation.
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Format a Unix-millisecond timestamp as `YYYY-MM-DDTHH:MM:SS.mmmZ`.
+///
+/// Uses Howard Hinnant's civil-calendar algorithm (public domain) to avoid
+/// pulling in extra feature flags from the `chrono` crate.
+fn format_millis(ms: i64) -> String {
+    let secs = ms.div_euclid(1000);
+    let ms_part = ms.rem_euclid(1000) as u32;
+
+    let days = secs.div_euclid(86400) as i32;
+    let time = secs.rem_euclid(86400) as u32;
+    let (h, mi, s) = (time / 3600, (time % 3600) / 60, time % 60);
+
+    // Gregorian date from days-since-epoch (Hinnant's civil.h)
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+
+    format!(
+        "{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.{ms_part:03}Z",
+        mo = mo as u32,
+        d = d as u32,
+    )
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSV escaping
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_owned()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Table tree (mirrors the hierarchy created by to_pg)
+// ──────────────────────────────────────────────────────────────────────────────
+
+struct TableNode {
+    /// SQL table name
+    sql_name: String,
+    /// Column names in declaration order (from SQL)
+    columns: Vec<String>,
+    /// Primary-key column name (always `"id"`)
+    pk_col: String,
+    /// FK column pointing to the parent table (`None` for root tables)
+    fk_col: Option<String>,
+    /// MongoDB field name at the current document level that yields this table's data.
+    /// Empty for the root table.
+    mongo_field: String,
+    /// `true` when this child table represents a scalar array
+    /// (has exactly 3 columns: pk, fk, `value`).
+    is_scalar_array: bool,
+    children: Vec<TableNode>,
+}
+
+fn build_tree(sql_tables: &[SqlTable]) -> Vec<TableNode> {
+    let names: std::collections::HashSet<&str> =
+        sql_tables.iter().map(|t| t.name.as_str()).collect();
+
+    // Map each child table to its parent (first FK that points to a table in this file)
+    let mut parent_of: HashMap<&str, &str> = HashMap::new();
+    for t in sql_tables {
+        for fk in &t.foreign_keys {
+            if names.contains(fk.to_table.as_str()) {
+                parent_of.insert(&t.name, &fk.to_table);
+                break;
+            }
+        }
+    }
+
+    // Invert: parent → children
+    let mut children_of: HashMap<&str, Vec<&SqlTable>> = HashMap::new();
+    for t in sql_tables {
+        if let Some(&par) = parent_of.get(t.name.as_str()) {
+            children_of.entry(par).or_default().push(t);
+        }
+    }
+
+    // Root = no parent
+    sql_tables
+        .iter()
+        .filter(|t| !parent_of.contains_key(t.name.as_str()))
+        .map(|r| build_node(r, None, &children_of))
+        .collect()
+}
+
+fn build_node(
+    sql_t: &SqlTable,
+    parent_name: Option<&str>,
+    children_of: &HashMap<&str, Vec<&SqlTable>>,
+) -> TableNode {
+    // The MongoDB field name is the suffix after stripping "<parent>_" from the table name.
+    let mongo_field = match parent_name {
+        Some(p) => sql_t
+            .name
+            .strip_prefix(&format!("{p}_"))
+            .unwrap_or(&sql_t.name)
+            .to_owned(),
+        None => String::new(),
+    };
+
+    let pk_col = sql_t
+        .columns
+        .iter()
+        .find(|c| c.primary_key)
+        .map(|c| c.name.clone())
+        .unwrap_or_else(|| "id".to_owned());
+
+    let fk_col = sql_t.foreign_keys.first().map(|fk| fk.from_col.clone());
+
+    let columns: Vec<String> = sql_t.columns.iter().map(|c| c.name.clone()).collect();
+
+    // A scalar-array child has exactly: pk, fk, value  (3 columns total)
+    let is_scalar_array =
+        fk_col.is_some() && columns.len() == 3 && columns.iter().any(|c| c == "value");
+
+    let children: Vec<TableNode> = children_of
+        .get(sql_t.name.as_str())
+        .map(|cs| {
+            cs.iter()
+                .map(|child_sql| build_node(child_sql, Some(&sql_t.name), children_of))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    TableNode {
+        sql_name: sql_t.name.clone(),
+        columns,
+        pk_col,
+        fk_col,
+        mongo_field,
+        is_scalar_array,
+        children,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// BSON field lookup
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Find `sql_col` in a BSON document.
+///
+/// Tries an exact-name match first, then falls back to comparing sanitized names
+/// so that e.g. `"invoiceId"` in MongoDB matches the `"invoiceid"` SQL column.
+fn find_mongo_field<'a>(doc: &'a bson::Document, sql_col: &str) -> Option<&'a Bson> {
+    if let Some(v) = doc.get(sql_col) {
+        return Some(v);
+    }
+    for (key, val) in doc.iter() {
+        if sanitize(key) == sql_col {
+            return Some(val);
+        }
+    }
+    None
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Row extraction  (recursive, depth-first)
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn extract_rows(
+    val: &Bson,
+    node: &TableNode,
+    parent_id: Option<&str>,
+    is_root: bool,
+    all_rows: &mut HashMap<String, Vec<Vec<String>>>,
+    counters: &mut HashMap<String, u64>,
+) {
+    let doc = match val {
+        Bson::Document(d) => d,
+        _ => return,
+    };
+
+    // Assign an ID for this row.
+    let my_id: String = if is_root {
+        // Root table: _id → id
+        doc.get("_id").map(bson_to_string).unwrap_or_default()
+    } else {
+        let c = counters.entry(node.sql_name.clone()).or_insert(0);
+        *c += 1;
+        c.to_string()
+    };
+
+    // Build the row by iterating SQL columns in order.
+    let row: Vec<String> = node
+        .columns
+        .iter()
+        .map(|col| {
+            if col == &node.pk_col {
+                my_id.clone()
+            } else if Some(col) == node.fk_col.as_ref() {
+                parent_id.unwrap_or("").to_owned()
+            } else {
+                find_mongo_field(doc, col)
+                    .map(bson_to_string)
+                    .unwrap_or_default()
+            }
+        })
+        .collect();
+
+    all_rows.entry(node.sql_name.clone()).or_default().push(row);
+
+    // Recurse into child tables.
+    for child in &node.children {
+        match find_mongo_field(doc, &child.mongo_field) {
+            Some(Bson::Array(arr)) => {
+                if child.is_scalar_array {
+                    // One row per scalar element.
+                    for item in arr {
+                        let child_id = {
+                            let c = counters.entry(child.sql_name.clone()).or_insert(0);
+                            *c += 1;
+                            c.to_string()
+                        };
+                        let child_row: Vec<String> = child
+                            .columns
+                            .iter()
+                            .map(|col| {
+                                if col == &child.pk_col {
+                                    child_id.clone()
+                                } else if Some(col) == child.fk_col.as_ref() {
+                                    my_id.clone()
+                                } else if col == "value" {
+                                    bson_to_string(item)
+                                } else {
+                                    String::new()
+                                }
+                            })
+                            .collect();
+                        all_rows
+                            .entry(child.sql_name.clone())
+                            .or_default()
+                            .push(child_row);
+                    }
+                } else {
+                    // One row per document element.
+                    for item in arr {
+                        extract_rows(item, child, Some(&my_id), false, all_rows, counters);
+                    }
+                }
+            }
+            Some(doc_val @ Bson::Document(_)) => {
+                // Embedded 1:1 object.
+                extract_rows(doc_val, child, Some(&my_id), false, all_rows, counters);
+            }
+            _ => {} // field absent or unexpected type – skip
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Export a single MongoDB collection to gzipped CSV files.
+///
+/// One `.csv.gz` file is written per SQL table (root + all child tables) into
+/// `<data_dir>/<coll_name>/`.  The SQL schema is read from
+/// `<tables_dir>/<coll_name>.sql`.
+///
+/// Returns the list of file paths that were written.
+pub async fn export_collection(
+    client: &Client,
+    db_name: &str,
+    coll_name: &str,
+    tables_dir: &Path,
+    data_dir: &Path,
+) -> Result<Vec<String>> {
+    let sql_path = tables_dir.join(format!("{coll_name}.sql"));
+    if !sql_path.exists() {
+        return Err(anyhow::anyhow!(
+            "SQL schema not found: {} – run `to-pg` first",
+            sql_path.display()
+        ));
+    }
+
+    let sql = std::fs::read_to_string(&sql_path)
+        .with_context(|| format!("Cannot read {}", sql_path.display()))?;
+
+    let sql_tables = parse_sql(&sql);
+    if sql_tables.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No CREATE TABLE statements found in {}",
+            sql_path.display()
+        ));
+    }
+
+    let roots = build_tree(&sql_tables);
+
+    // Stream all documents from the collection.
+    let db = client.database(db_name);
+    let collection = db.collection::<bson::Document>(coll_name);
+    let mut cursor = collection
+        .find(bson::doc! {})
+        .await
+        .with_context(|| format!("Failed to query {db_name}.{coll_name}"))?;
+
+    let mut all_rows: HashMap<String, Vec<Vec<String>>> = HashMap::new();
+    let mut counters: HashMap<String, u64> = HashMap::new();
+
+    while let Some(doc) = cursor.try_next().await.context("Cursor error")? {
+        let bson_val = Bson::Document(doc);
+        for root in &roots {
+            extract_rows(&bson_val, root, None, true, &mut all_rows, &mut counters);
+        }
+    }
+
+    // Write one .csv.gz per SQL table.
+    let out_dir = data_dir.join(coll_name);
+    std::fs::create_dir_all(&out_dir)
+        .with_context(|| format!("Cannot create {}", out_dir.display()))?;
+
+    let mut written: Vec<String> = Vec::new();
+
+    for sql_t in &sql_tables {
+        let columns: Vec<String> = sql_t.columns.iter().map(|c| c.name.clone()).collect();
+        let rows = all_rows.get(&sql_t.name).cloned().unwrap_or_default();
+
+        let csv_path = out_dir.join(format!("{}.csv.gz", sql_t.name));
+        let file = std::fs::File::create(&csv_path)
+            .with_context(|| format!("Cannot create {}", csv_path.display()))?;
+        let mut gz = GzEncoder::new(file, Compression::default());
+
+        // Header row
+        let header: Vec<String> = columns.iter().map(|c| csv_escape(c)).collect();
+        writeln!(gz, "{}", header.join(","))
+            .with_context(|| format!("Write error for {}", csv_path.display()))?;
+
+        // Data rows
+        for row in &rows {
+            let line: Vec<String> = row.iter().map(|v| csv_escape(v)).collect();
+            writeln!(gz, "{}", line.join(","))
+                .with_context(|| format!("Write error for {}", csv_path.display()))?;
+        }
+
+        gz.finish()
+            .with_context(|| format!("GZ flush error for {}", csv_path.display()))?;
+
+        eprintln!("  {} rows → {}", rows.len(), csv_path.display());
+        written.push(csv_path.display().to_string());
+    }
+
+    Ok(written)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod analyzer;
 pub mod converters;
+pub mod export;
 pub mod report;
 pub mod schema_diagram;
 pub mod stats;


### PR DESCRIPTION
fix #26 
This pull request introduces a new feature to export MongoDB data as gzipped CSV files, along with updates to the documentation and command-line interface to support this functionality. The new `export` subcommand allows users to export data for all or specific collections, making it easier to migrate data into PostgreSQL. Documentation has been updated to reflect this new workflow and provide usage examples.

**New export feature:**

* Adds a new `export` subcommand to the CLI, enabling export of MongoDB data to gzipped CSV files (one per SQL table), with options to select collections and output directories (`src/bin/mongo2pg.rs`, `src/lib.rs`) [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR64-R65) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR172-R185) [[3]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR198) [[4]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR492-R556) [[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R12).
* Introduces the `flate2` dependency for handling gzip compression (`Cargo.toml`).

**Documentation updates:**

* Updates `README.md` and `USAGE.md` to describe the new `export` command, its arguments, options, output layout, and how to load the resulting CSV files into PostgreSQL [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R61) [[2]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR548-R594) [[3]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dL589-R639) [[4]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR665-R673).

**Other code changes:**

* Imports the new `export_collection` function where needed (`src/bin/mongo2pg.rs`).