### PR TITLE
fix: error 292

### DIFF
--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -599,6 +599,7 @@ async fn infer_collection(
     let pipeline = vec![doc! { "$sample": { "size": sample_size as i64 } }];
     let mut cursor = collection
         .aggregate(pipeline)
+        .allow_disk_use(true)
         .await
         .with_context(|| format!("Failed to run $sample aggregation on {db_name}.{coll_name}"))?;
     while let Some(doc) = cursor.try_next().await.context("Cursor error")? {


### PR DESCRIPTION
This pull request makes a targeted improvement to the MongoDB aggregation pipeline used in the `infer_collection` function. The change enables disk use for the `$sample` aggregation, which allows MongoDB to handle larger datasets during sampling without running into memory limitations.

**MongoDB aggregation improvement:**

* [`src/bin/mongo2pg.rs`](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR602): Added `.allow_disk_use(true)` to the aggregation pipeline in the `infer_collection` function, enabling disk use during `$sample` operations to support larger collections.