### PR TITLE
Feat/add schema

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,5 @@
+[sqlfluff]
+dialect = postgres
+
+[sqlfluff:rules:references.keywords]
+ignore_words = name, type, value, key, level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`to-pg --schema <NAME>`**: deploy all tables for a collection into a dedicated PostgreSQL schema
+  - Prepends `CREATE SCHEMA IF NOT EXISTS <name>; SET search_path = <name>;` to the generated SQL
+  - Strips the `{schema}_` prefix from every child table name so names are shorter and schema-qualified references are unambiguous (e.g. `b2bsalesorder_lines` → `lines` inside schema `b2bsalesorder`)
+  - Prefix matching is case-insensitive (sanitized before comparison) to handle mixed-case collection names
+- **`to-pg --schema-per-collection`**: equivalent to `--schema <collection_name>` applied to every collection processed in a batch; each output file gets its own self-contained schema preamble. Mutually exclusive with `--schema`
+- **Output SQL filenames are now lowercased**: `B2BSalesOrder.sql` → `b2bsalesorder.sql`, consistent with PostgreSQL identifier folding
+
 ### Fixed
 
 - **`$sample` sort-memory failures no longer abort inference**: when `$sample` fails with a sort-memory-limit error (MongoDB error 292, common on Atlas shared/free tiers) or any other aggregation error, the tool now automatically falls back to `find().limit(<sample_size>)`, which has no sort stage and works on all tiers

--- a/USAGE.md
+++ b/USAGE.md
@@ -663,7 +663,7 @@ CREATE SCHEMA IF NOT EXISTS product;
 SET search_path = product;
 
 CREATE TABLE product ( … );
-CREATE TABLE product_variants ( … );
+CREATE TABLE variants ( … );
 …
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -566,8 +566,106 @@ mongo2pg to-pg [COLLECTION] [OPTIONS]
 | `-c, --config <FILE>` | Project config file – reads `source/collections/`, writes `schema/tables/` |
 | `-o, --output-dir <DIR>` | Directory to write `.sql` files into (overrides `-c`) |
 | `-t, --table <NAME>` | Table name override (single collection only) |
+| `--schema <NAME>` | Deploy all tables into the PostgreSQL schema `<NAME>` (see below) |
+| `--schema-per-collection` | Like `--schema` but uses each collection name as its own schema (see below) |
 
 Reads `source/collections/<name>/<name>.json` and writes `schema/tables/<name>.sql`.
+
+---
+
+### Why `--schema` and `--schema-per-collection`?
+
+MongoDB collections are often deeply nested. When `to-pg` flattens nested documents
+into relational tables, child table names are built by concatenating their parent
+names with underscores:
+
+```
+salesorder
+salesorder_lines
+salesorder_lines_fulfillmentmaplines
+salesorder_lines_fulfillmentmaplines_route
+salesorder_lines_fulfillmentmaplines_route_sourcinglocation
+salesorder_lines_fulfillmentmaplines_route_sourcinglocation_purchasecondition  ← 84 chars!
+```
+
+PostgreSQL silently truncates identifiers longer than **63 bytes**, which causes
+name collisions in large schemas.  More practically, when you plan to deploy a
+collection into its own dedicated PostgreSQL schema (one schema per collection
+is a common pattern), the collection name prefix on every table name is redundant
+noise.
+
+`--schema` and `--schema-per-collection` address both problems:
+
+1. **Each child table name has the `{schema}_` prefix stripped** before it is
+   written, so names are shorter and collision-free.
+2. **A `CREATE SCHEMA` preamble is prepended** to the generated SQL so the schema
+   is created automatically when you run the file.
+3. **`SET search_path`** is set at the top of the file so all `CREATE TABLE` and
+   `REFERENCES` statements resolve within the schema without needing to be qualified.
+
+**Before** (no flag):
+
+```sql
+CREATE TABLE salesorder ( … );
+CREATE TABLE salesorder_lines ( … );
+CREATE TABLE salesorder_lines_fulfillmentmaplines ( … );
+CREATE TABLE salesorder_lines_fulfillmentmaplines_route ( … );
+```
+
+**After** (`--schema salesorder`):
+
+```sql
+CREATE SCHEMA IF NOT EXISTS salesorder;
+SET search_path = salesorder;
+
+CREATE TABLE salesorder ( … );   -- root table keeps its name
+CREATE TABLE lines ( … );           -- prefix stripped
+CREATE TABLE lines_fulfillmentmaplines ( … );
+CREATE TABLE lines_fulfillmentmaplines_route ( … );
+```
+
+#### `--schema <NAME>`
+
+Applies a single fixed schema name to the output. Useful when converting a single
+collection, or when all collections in a project share one schema.
+
+```bash
+# Single collection deployed into its own schema
+mongo2pg to-pg -c config/sofi.conf salesorder --schema salesorder
+```
+
+#### `--schema-per-collection`
+
+Equivalent to running `--schema <collection_name>` for every collection processed.
+Each output file gets its own `CREATE SCHEMA` preamble and its tables are named
+without the collection prefix.  Mutually exclusive with `--schema`.
+
+```bash
+# Every collection gets deployed into its own schema
+mongo2pg to-pg -c config/sofi.conf --schema-per-collection
+```
+
+This produces one `.sql` file per collection, each self-contained:
+
+```sql
+-- salesorder.sql
+CREATE SCHEMA IF NOT EXISTS salesorder;
+SET search_path = salesorder;
+
+CREATE TABLE salesorder ( … );
+CREATE TABLE lines ( … );
+…
+```
+
+```sql
+-- product.sql
+CREATE SCHEMA IF NOT EXISTS product;
+SET search_path = product;
+
+CREATE TABLE product ( … );
+CREATE TABLE product_variants ( … );
+…
+```
 
 ---
 
@@ -685,6 +783,12 @@ mongo2pg to-pg -c config/retail.conf
 
 # Convert a single collection only
 mongo2pg to-pg -c config/retail.conf products
+
+# Deploy each collection into its own PostgreSQL schema (strips collection prefix from child table names)
+mongo2pg to-pg -c config/retail.conf --schema-per-collection
+
+# Deploy a single collection into a named schema
+mongo2pg to-pg -c config/retail.conf orders --schema orders
 
 # Generate reports
 mongo2pg report -c config/retail.conf

--- a/USAGE.md
+++ b/USAGE.md
@@ -630,8 +630,8 @@ Applies a single fixed schema name to the output. Useful when converting a singl
 collection, or when all collections in a project share one schema.
 
 ```bash
-# Single collection deployed into its own schema
-mongo2pg to-pg -c config/sofi.conf salesorder --schema salesorder
+# Single collection deployed into its own schema (sales is the dbname, salesorder is the collection)
+mongo2pg to-pg -c config/sofi.conf sales.salesorder --schema salesorder
 ```
 
 #### `--schema-per-collection`

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -138,6 +138,16 @@ struct ToPgArgs {
     /// Directory to write the SQL file(s) into (overrides -c)
     #[arg(short = 'o', long = "output-dir", conflicts_with = "config")]
     output_dir: Option<PathBuf>,
+
+    /// PostgreSQL schema name: strips `{schema}_` prefix from child table names and
+    /// prepends `CREATE SCHEMA IF NOT EXISTS` + `SET search_path` to the output.
+    #[arg(long = "schema", conflicts_with = "schema_per_collection")]
+    schema: Option<String>,
+
+    /// Use each collection name as its own PostgreSQL schema: equivalent to `--schema <collection>`
+    /// applied per collection. Mutually exclusive with `--schema`.
+    #[arg(long = "schema-per-collection", action = clap::ArgAction::SetTrue)]
+    schema_per_collection: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -286,14 +296,14 @@ fn run_to_pg(args: ToPgArgs) -> Result<()> {
         // Single collection specified – try flat layout first, then per-db.
         let flat = collections_dir.join(name).join(format!("{name}.json"));
         if flat.exists() {
-            vec![(PathBuf::from(format!("{name}.sql")), flat)]
+            vec![(PathBuf::from(format!("{}.sql", name.to_lowercase())), flat)]
         } else if name.contains('/') {
             // Caller passed "db/collection"
             let json = collections_dir.join(name).join({
                 let coll = name.split('/').next_back().unwrap_or(name);
                 format!("{coll}.json")
             });
-            vec![(PathBuf::from(format!("{name}.sql")), json)]
+            vec![(PathBuf::from(format!("{}.sql", name.to_lowercase())), json)]
         } else {
             return Err(anyhow!(
                 "Collection '{}' not found under {}",
@@ -316,7 +326,10 @@ fn run_to_pg(args: ToPgArgs) -> Result<()> {
 
             if direct_json.exists() {
                 // Flat layout: <collections_dir>/<name>/<name>.json
-                entries.push((PathBuf::from(format!("{top_name}.sql")), direct_json));
+                entries.push((
+                    PathBuf::from(format!("{}.sql", top_name.to_lowercase())),
+                    direct_json,
+                ));
             } else {
                 // Per-db layout: treat this dir as a database folder
                 let mut sub_dirs: Vec<(PathBuf, PathBuf)> = std::fs::read_dir(&top_path)
@@ -327,7 +340,14 @@ fn run_to_pg(args: ToPgArgs) -> Result<()> {
                         let coll_name = e.file_name().to_string_lossy().into_owned();
                         let json = e.path().join(format!("{coll_name}.json"));
                         if json.exists() {
-                            Some((PathBuf::from(format!("{top_name}/{coll_name}.sql")), json))
+                            Some((
+                                PathBuf::from(format!(
+                                    "{}/{}.sql",
+                                    top_name.to_lowercase(),
+                                    coll_name.to_lowercase()
+                                )),
+                                json,
+                            ))
                         } else {
                             None
                         }
@@ -366,7 +386,15 @@ fn run_to_pg(args: ToPgArgs) -> Result<()> {
             .with_context(|| format!("Failed to read {}", json_path.display()))?;
         let schema: CollectionSchema = serde_json::from_str(&content)
             .with_context(|| format!("Failed to parse {}", json_path.display()))?;
-        let ddl = schema_to_ddl(&schema, table_name);
+        let ddl = schema_to_ddl(
+            &schema,
+            table_name,
+            if args.schema_per_collection {
+                Some(table_name)
+            } else {
+                args.schema.as_deref()
+            },
+        );
         std::fs::write(&sql_path, &ddl)
             .with_context(|| format!("Failed to write {}", sql_path.display()))?;
         println!("SQL written to {}", sql_path.display());

--- a/src/to_pg.rs
+++ b/src/to_pg.rs
@@ -433,6 +433,33 @@ fn map_value_fields(doc_ts: &TypeSchema) -> Option<&IndexMap<String, FieldSchema
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Child table name helper
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Build a child table name, stripping the `{schema}_` prefix when `pg_schema`
+/// is provided so that tables deployed inside a dedicated schema have shorter names.
+fn child_table_name(parent_name: &str, field: &str, pg_schema: Option<&str>) -> String {
+    let raw = format!("{parent_name}_{field}");
+    if let Some(schema) = pg_schema {
+        let prefix = format!("{}_", sanitize(schema));
+        raw.strip_prefix(&prefix).map(str::to_owned).unwrap_or(raw)
+    } else {
+        raw
+    }
+}
+
+/// Optionally prepend `CREATE SCHEMA` + `SET search_path` preamble.
+fn prepend_schema_preamble(ddl: String, pg_schema: Option<&str>) -> String {
+    match pg_schema {
+        None => ddl,
+        Some(schema) => {
+            let s = sanitize(schema);
+            format!("CREATE SCHEMA IF NOT EXISTS {s};\nSET search_path = {s};\n\n{ddl}")
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Child table builders
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -440,8 +467,9 @@ fn add_child_table(
     parent: &mut Table,
     array_field_col: &str,
     child_fields: &IndexMap<String, FieldSchema>,
+    pg_schema: Option<&str>,
 ) {
-    let child_name = format!("{}_{}", parent.name, array_field_col);
+    let child_name = child_table_name(&parent.name, array_field_col, pg_schema);
     let (pk_name, pk_type) = find_pk(parent);
     let fk_col = format!("{}_id", parent.name);
 
@@ -460,7 +488,7 @@ fn add_child_table(
     });
     child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
 
-    process_fields(&mut child, child_fields, "", true);
+    process_fields(&mut child, child_fields, "", true, pg_schema);
     parent.child_tables.push(child);
 }
 
@@ -468,8 +496,9 @@ fn add_scalar_array_table(
     parent: &mut Table,
     array_field_col: &str,
     scalar_types: &[(&str, &TypeSchema)],
+    pg_schema: Option<&str>,
 ) {
-    let child_name = format!("{}_{}", parent.name, array_field_col);
+    let child_name = child_table_name(&parent.name, array_field_col, pg_schema);
     let (pk_name, pk_type) = find_pk(parent);
     let fk_col = format!("{}_id", parent.name);
 
@@ -513,8 +542,9 @@ fn add_doc_table(
     parent: &mut Table,
     doc_field_col: &str,
     doc_fields: &IndexMap<String, FieldSchema>,
+    pg_schema: Option<&str>,
 ) {
-    let child_name = format!("{}_{}", parent.name, doc_field_col);
+    let child_name = child_table_name(&parent.name, doc_field_col, pg_schema);
     let (pk_name, pk_type) = find_pk(parent);
     let fk_col = format!("{}_id", parent.name);
 
@@ -533,7 +563,7 @@ fn add_doc_table(
     });
     child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
 
-    process_fields(&mut child, doc_fields, "", false);
+    process_fields(&mut child, doc_fields, "", false, pg_schema);
     parent.child_tables.push(child);
 }
 
@@ -543,8 +573,9 @@ fn add_map_table(
     parent: &mut Table,
     map_field_col: &str,
     value_fields: &IndexMap<String, FieldSchema>,
+    pg_schema: Option<&str>,
 ) {
-    let child_name = format!("{}_{}", parent.name, map_field_col);
+    let child_name = child_table_name(&parent.name, map_field_col, pg_schema);
     let (pk_name, pk_type) = find_pk(parent);
     let fk_col = format!("{}_id", parent.name);
 
@@ -569,7 +600,7 @@ fn add_map_table(
         primary_key: false,
     });
 
-    process_fields(&mut child, value_fields, "", false);
+    process_fields(&mut child, value_fields, "", false, pg_schema);
     parent.child_tables.push(child);
 }
 
@@ -578,6 +609,7 @@ fn handle_array_field(
     col_name: &str,
     items_field: &FieldSchema,
     nullable: bool,
+    pg_schema: Option<&str>,
 ) {
     let non_null_items: Vec<(&str, &TypeSchema)> = items_field
         .types
@@ -590,7 +622,7 @@ fn handle_array_field(
         // Array of documents → child table (one row per array element)
         if let Some(child_fields) = &doc_ts.object {
             let cf = child_fields.clone();
-            add_child_table(table, col_name, &cf);
+            add_child_table(table, col_name, &cf, pg_schema);
         } else {
             // Object type but no inner fields schema
             table.columns.push(Column {
@@ -602,7 +634,7 @@ fn handle_array_field(
         }
     } else {
         // Array of scalars → child table with `value` column
-        add_scalar_array_table(table, col_name, &non_null_items);
+        add_scalar_array_table(table, col_name, &non_null_items, pg_schema);
     }
 }
 
@@ -615,6 +647,7 @@ fn process_fields(
     fields: &IndexMap<String, FieldSchema>,
     col_prefix: &str,
     mark_pk: bool,
+    pg_schema: Option<&str>,
 ) {
     for (raw_name, field) in fields {
         let col_name = sanitize(&format!("{col_prefix}{raw_name}"));
@@ -659,7 +692,7 @@ fn process_fields(
                 // Map document (dynamic hex keys)
                 let value_fields = map_value_fields(ts).map(|vf| vf.clone());
                 if let Some(vf) = value_fields {
-                    add_map_table(table, &col_name, &vf);
+                    add_map_table(table, &col_name, &vf, pg_schema);
                 } else {
                     table.columns.push(Column {
                         name: col_name,
@@ -670,7 +703,7 @@ fn process_fields(
                 }
             } else if let Some(sub_fields) = &ts.object {
                 let sf = sub_fields.clone();
-                add_doc_table(table, &col_name, &sf);
+                add_doc_table(table, &col_name, &sf, pg_schema);
             } else {
                 // Object type but no inner field schema (empty document)
                 table.columns.push(Column {
@@ -688,7 +721,7 @@ fn process_fields(
             let ts = non_null[0].1;
             if let Some(items_field) = &ts.array {
                 let items = *items_field.clone();
-                handle_array_field(table, &col_name, &items, nullable);
+                handle_array_field(table, &col_name, &items, nullable, pg_schema);
             } else {
                 // Array with no items schema → JSONB
                 table.columns.push(Column {
@@ -810,9 +843,13 @@ fn render_table(table: &Table) -> String {
 ///
 /// # Returns
 /// A string containing one or more `CREATE TABLE` statements separated by blank lines.
-pub fn schema_to_ddl(schema: &CollectionSchema, table_name: &str) -> String {
+pub fn schema_to_ddl(
+    schema: &CollectionSchema,
+    table_name: &str,
+    pg_schema: Option<&str>,
+) -> String {
     let mut root = Table::new(sanitize(table_name));
-    process_fields(&mut root, &schema.object, "", true);
+    process_fields(&mut root, &schema.object, "", true, pg_schema);
 
     let tables = collect_tables(&root);
     let total_cols: usize = tables.iter().map(|t| t.columns.len()).sum();
@@ -820,11 +857,12 @@ pub fn schema_to_ddl(schema: &CollectionSchema, table_name: &str) -> String {
     eprintln!("tables : {}", tables.len());
     eprintln!("columns: {total_cols}");
 
-    tables
+    let ddl = tables
         .iter()
         .map(|t| render_table(t))
         .collect::<Vec<_>>()
-        .join("\n\n")
+        .join("\n\n");
+    prepend_schema_preamble(ddl, pg_schema)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -852,7 +890,7 @@ mod tests {
             doc! { "_id": 2_i32, "name": "Bob",   "score": 88_i32 },
         ];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "users");
+        let ddl = schema_to_ddl(&schema, "users", None);
         assert!(ddl.contains("CREATE TABLE users ("), "root table missing");
         assert!(ddl.contains("name TEXT"), "name column missing");
         assert!(ddl.contains("score"), "score column missing");
@@ -865,7 +903,7 @@ mod tests {
             doc! { "_id": 2_i32 },
         ];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "t");
+        let ddl = schema_to_ddl(&schema, "t", None);
         // opt must not be NOT NULL
         assert!(
             !ddl.contains("opt TEXT NOT NULL"),
@@ -877,7 +915,7 @@ mod tests {
     fn test_objectid_pk_becomes_uuid() {
         let docs = vec![doc! { "_id": bson::oid::ObjectId::new(), "x": 1_i32 }];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "t");
+        let ddl = schema_to_ddl(&schema, "t", None);
         assert!(
             ddl.contains("id UUID PRIMARY KEY"),
             "ObjectId PK should become UUID"
@@ -888,7 +926,7 @@ mod tests {
     fn test_nested_object_creates_child_table() {
         let docs = vec![doc! { "_id": 1_i32, "addr": { "city": "Paris" } }];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "orders");
+        let ddl = schema_to_ddl(&schema, "orders", None);
         assert!(
             ddl.contains("CREATE TABLE orders_addr ("),
             "child table for addr missing"
@@ -900,7 +938,7 @@ mod tests {
     fn test_array_of_scalars_creates_child_table() {
         let docs = vec![doc! { "_id": 1_i32, "tags": ["rust", "mongodb"] }];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "posts");
+        let ddl = schema_to_ddl(&schema, "posts", None);
         assert!(
             ddl.contains("CREATE TABLE posts_tags ("),
             "scalar array child table missing"
@@ -912,7 +950,7 @@ mod tests {
     fn test_reserved_word_prefixed() {
         let docs = vec![doc! { "_id": 1_i32, "order": "asc" }];
         let schema = analyze(&docs);
-        let ddl = schema_to_ddl(&schema, "t");
+        let ddl = schema_to_ddl(&schema, "t", None);
         assert!(
             ddl.contains("_order"),
             "reserved word 'order' should be prefixed with _"


### PR DESCRIPTION
This pull request adds support for deploying each MongoDB collection into its own PostgreSQL schema, addressing issues with long table names and redundant prefixes in large, nested schemas. It introduces the `--schema` and `--schema-per-collection` options to the CLI, updates the SQL generation logic to strip redundant prefixes from child table names, and prepends schema preambles to the output SQL. The documentation and tests are updated to reflect these changes.

**New features and CLI options:**

* Added `--schema <NAME>` and `--schema-per-collection` options to the `to-pg` command, allowing users to deploy tables into a specific PostgreSQL schema or one schema per collection. These options strip the collection prefix from child table names and add a `CREATE SCHEMA` and `SET search_path` preamble to the output SQL. [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR141-R150) [[2]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR569-R671) [[3]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR787-R792)

**SQL generation and naming improvements:**

* Updated table name generation to strip the `{schema}_` prefix from child table names when a schema is specified, resulting in shorter, collision-free names. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R435-R461) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R470-R472)
* Modified the SQL output to include schema preambles (`CREATE SCHEMA IF NOT EXISTS` and `SET search_path`) when a schema is specified. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R435-R461) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L813-R865)

**Code and test updates:**

* Refactored functions throughout `src/to_pg.rs` to pass the schema context for correct table naming and preamble generation. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R470-R472) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L463-R501) [[3]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R545-R547) [[4]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R576-R578) [[5]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R612) [[6]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L593-R625) [[7]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L605-R637) [[8]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R650) [[9]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L662-R695) [[10]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L673-R706) [[11]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L691-R724)
* Updated tests to use the new `schema_to_ddl` signature with the optional schema parameter. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L855-R893) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L868-R906) [[3]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L880-R918)

**Documentation:**

* Expanded the `USAGE.md` documentation to explain the new schema options, their rationale, and provided usage examples. [[1]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR569-R671) [[2]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR787-R792)

**Other improvements:**

* Standardized output SQL file naming to use lowercase names and clarified logic for multi-collection and per-database layouts. [[1]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL289-R306) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL319-R332) [[3]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL330-R350) [[4]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL369-R397)

**Configuration:**

* Added a `.sqlfluff` configuration file specifying the PostgreSQL dialect and keywords to ignore for linting.