### PR TITLE
fix(export): export command failure with CamelCase collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-database errors no longer abort server-wide inference**: if `list_collection_names()` fails for a database, that database is skipped with a warning and iteration continues
 - **`estimated_document_count()` failure is now non-fatal**: falls back to the number of sampled documents instead of propagating the error
 - **`SAMPLE_MAX_TIME` cap (120 s) added** to both the `$sample` aggregation and the `find()` fallback to prevent runaway queries
+- **`export` now resolves SQL schemas by sanitized collection name only**: MongoDB collection names stay raw for querying, but schema lookup uses the lowercased sanitized filename (for example `listingsAndReviews` → `listingsandreviews.sql`), fixing mixed-case collection/export mismatches
+- **`export --namespace` now overrides the config namespace consistently**: export reads SQL from `schema/tables/<db_name>/` with no fallback to older flat locations
+- **Export output layout is now database-scoped**: generated `.csv.gz` files are written under `data/<database_name>/<sanitized_collection_name>/`
+- **Export output now prints the resolved `.csv.gz` path for each table**: row counts are logged alongside the final file location during export
 - **`mongodb` dependency bumped** from 3.2.5 to 3.6.0
 
 ---

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -860,7 +860,8 @@ async fn run_export(args: ExportArgs) -> Result<()> {
     })?;
 
     let project_root = c.base_dir.join(&c.project_dir);
-    let tables_dir = project_root.join("schema").join("tables");
+    // Use <project_root>/schema/tables/<db_name> for SQL files
+    let tables_dir = project_root.join("schema").join("tables").join(&db_name);
     let data_dir = args
         .output_dir
         .clone()
@@ -872,10 +873,31 @@ async fn run_export(args: ExportArgs) -> Result<()> {
     let client = Client::with_options(client_options).context("Failed to create MongoDB client")?;
 
     // Determine which collections to export
+    // Helper: sanitize a name like to_pg::sanitize
+    fn sanitize(name: &str) -> String {
+        let mut s = name.replace(|c: char| !c.is_ascii_alphanumeric() && c != '_', "_");
+        if s.chars().next().map_or(false, |c| c.is_ascii_digit()) {
+            s = format!("_{}", s);
+        }
+        s.to_lowercase()
+    }
+
     let collections: Vec<String> = if let Some(name) = args.collection.clone() {
-        vec![name]
+        // If a specific collection is requested, check for its sanitized .sql file
+        let sanitized = sanitize(&name);
+        let sql_path = tables_dir.join(format!("{sanitized}.sql"));
+        if sql_path.exists() {
+            vec![name]
+        } else {
+            eprintln!(
+                "  warning: SQL schema not found: {} – run `to-pg` first",
+                sql_path.display()
+            );
+            Vec::new()
+        }
     } else {
-        let mut names: Vec<String> = std::fs::read_dir(&tables_dir)
+        // Get all .sql files and their sanitized names
+        let mut sql_files: Vec<(String, String)> = std::fs::read_dir(&tables_dir)
             .with_context(|| format!("Cannot read {}", tables_dir.display()))?
             .filter_map(|e| e.ok())
             .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("sql"))
@@ -883,11 +905,34 @@ async fn run_export(args: ExportArgs) -> Result<()> {
                 e.path()
                     .file_stem()
                     .and_then(|s| s.to_str())
-                    .map(|s| s.to_owned())
+                    .map(|s| (s.to_owned(), sanitize(s)))
             })
             .collect();
-        names.sort();
-        names
+        sql_files.sort_by(|a, b| a.1.cmp(&b.1));
+
+        // Build a set of sanitized .sql names for fast lookup
+        use std::collections::HashSet;
+        let sql_set: HashSet<String> = sql_files.iter().map(|(_, s)| s.clone()).collect();
+
+        // Get all collection names from MongoDB
+        let mongo_colls = client.database(&db_name).list_collection_names().await?;
+
+        // For each collection, if its sanitized name matches a sanitized .sql file, export it
+        let mut matched = Vec::new();
+        for coll in mongo_colls {
+            let sanitized = sanitize(&coll);
+            let sql_path = tables_dir.join(format!("{sanitized}.sql"));
+            if sql_set.contains(&sanitized) && sql_path.exists() {
+                matched.push(coll);
+            } else {
+                eprintln!(
+                    "  warning: SQL schema not found: {} – run `to-pg` first",
+                    sql_path.display()
+                );
+            }
+        }
+        matched.sort();
+        matched
     };
 
     if collections.is_empty() {
@@ -898,11 +943,7 @@ async fn run_export(args: ExportArgs) -> Result<()> {
     for coll_name in &collections {
         eprintln!("[{db_name}.{coll_name}]");
         match export_collection(&client, &db_name, coll_name, &tables_dir, &data_dir).await {
-            Ok(files) => {
-                for f in files {
-                    println!("{f}");
-                }
-            }
+            Ok(()) => {}
             Err(e) => eprintln!("  warning: {e}"),
         }
     }

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -225,6 +225,13 @@ struct ExportArgs {
     /// Override the output directory for CSV files (default: <project>/data/)
     #[arg(short = 'o', long = "output-dir")]
     output_dir: Option<PathBuf>,
+
+    /// Namespace: either <db>.<collection> to export one collection, or just <db> to export all
+    /// collections in the database. When omitted (and -c is not given) all user databases on the
+    /// server are enumerated and exported (admin, local, and config are skipped). Can also be set
+    /// via NAMESPACE in the config file. This overrides the namespace in the config file if provided.
+    #[arg(long = "namespace")]
+    namespace: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -846,9 +853,11 @@ async fn run_export(args: ExportArgs) -> Result<()> {
         .clone()
         .or(c.uri)
         .ok_or_else(|| anyhow!("No URI provided: pass --uri or add URI to the config file"))?;
-    let db_name = c
-        .namespace
-        .ok_or_else(|| anyhow!("No NAMESPACE in config file"))?;
+
+    // Use args.namespace if provided, else fall back to config file
+    let db_name = args.namespace.clone().or(c.namespace).ok_or_else(|| {
+        anyhow!("No NAMESPACE provided: pass --namespace or add NAMESPACE to the config file")
+    })?;
 
     let project_root = c.base_dir.join(&c.project_dir);
     let tables_dir = project_root.join("schema").join("tables");

--- a/src/export.rs
+++ b/src/export.rs
@@ -482,7 +482,7 @@ fn extract_rows(
 /// Export a single MongoDB collection to gzipped CSV files.
 ///
 /// One `.csv.gz` file is written per SQL table (root + all child tables) into
-/// `<data_dir>/<coll_name>/`.  The SQL schema is read from
+/// `<data_dir>/<db_name>/<sanitize(coll_name)>/`.  The SQL schema is read from
 /// `<tables_dir>/<sanitize(coll_name)>.sql`.
 pub async fn export_collection(
     client: &Client,
@@ -491,7 +491,9 @@ pub async fn export_collection(
     tables_dir: &Path,
     data_dir: &Path,
 ) -> Result<()> {
-    let sql_path = tables_dir.join(format!("{}.sql", sanitize(coll_name)));
+    // Only the SQL filename is sanitized; the MongoDB collection name must stay raw.
+    let sql_lookup_name = sanitize(coll_name);
+    let sql_path = tables_dir.join(format!("{sql_lookup_name}.sql"));
     if !sql_path.exists() {
         return Err(anyhow::anyhow!(
             "SQL schema not found: {} – run `to-pg` first",
@@ -512,7 +514,7 @@ pub async fn export_collection(
 
     let roots = build_tree(&sql_tables);
 
-    // Stream all documents from the collection.
+    // Query MongoDB using the original collection name.
     let db = client.database(db_name);
     let collection = db.collection::<bson::Document>(coll_name);
     let mut cursor = collection
@@ -530,8 +532,8 @@ pub async fn export_collection(
         }
     }
 
-    // Write one .csv.gz per SQL table.
-    let out_dir = data_dir.join(coll_name);
+    // Keep the database name raw, but sanitize the collection folder for filesystem safety.
+    let out_dir = data_dir.join(db_name).join(&sql_lookup_name);
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("Cannot create {}", out_dir.display()))?;
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -483,17 +483,15 @@ fn extract_rows(
 ///
 /// One `.csv.gz` file is written per SQL table (root + all child tables) into
 /// `<data_dir>/<coll_name>/`.  The SQL schema is read from
-/// `<tables_dir>/<coll_name>.sql`.
-///
-/// Returns the list of file paths that were written.
+/// `<tables_dir>/<sanitize(coll_name)>.sql`.
 pub async fn export_collection(
     client: &Client,
     db_name: &str,
     coll_name: &str,
     tables_dir: &Path,
     data_dir: &Path,
-) -> Result<Vec<String>> {
-    let sql_path = tables_dir.join(format!("{coll_name}.sql"));
+) -> Result<()> {
+    let sql_path = tables_dir.join(format!("{}.sql", sanitize(coll_name)));
     if !sql_path.exists() {
         return Err(anyhow::anyhow!(
             "SQL schema not found: {} – run `to-pg` first",
@@ -537,8 +535,6 @@ pub async fn export_collection(
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("Cannot create {}", out_dir.display()))?;
 
-    let mut written: Vec<String> = Vec::new();
-
     for sql_t in &sql_tables {
         let columns: Vec<String> = sql_t.columns.iter().map(|c| c.name.clone()).collect();
         let rows = all_rows.get(&sql_t.name).cloned().unwrap_or_default();
@@ -563,9 +559,9 @@ pub async fn export_collection(
         gz.finish()
             .with_context(|| format!("GZ flush error for {}", csv_path.display()))?;
 
-        eprintln!("  {} rows → {}", rows.len(), csv_path.display());
-        written.push(csv_path.display().to_string());
+        let resolved_csv_path = std::fs::canonicalize(&csv_path).unwrap_or(csv_path.clone());
+        eprintln!("  {} rows -> {}", rows.len(), resolved_csv_path.display());
     }
 
-    Ok(written)
+    Ok(())
 }

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -347,7 +347,30 @@ directly with `\COPY`:
 \COPY orders_status_history FROM PROGRAM 'gunzip -c orders_status_history.csv.gz' CSV HEADER;
 ```
 
+Create tables
+
+```bash
+export PGURI="postgres://avnadmin:<redacted>@pg-testpmp-fras-d-pmp-todel.j.aivencloud.com:12833/defaultdb?sslmode=require"
+find mongo2pg/mongodb-testpmp/schema/tables/sample_airbnb -maxdepth 1 -type f -name '*.sql' | while read -r f; do
+  echo "executing psql -f $f"
+  psql "$PGURI" -f $f
+done
+```
+
 Load parent tables before child tables to satisfy foreign-key constraints.
+
+
+```bash
+{
+  echo "BEGIN;"
+  echo "SET CONSTRAINTS ALL DEFERRED;"
+  find mongo2pg/mongodb-testpmp/data/sample_airbnb -mindepth 2 -maxdepth 2 -type f -name '*.csv.gz' | sort | while read -r f; do
+    table=$(basename "$f" .csv.gz)
+    printf "\\COPY %s FROM PROGRAM 'gunzip -c %s' CSV HEADER;\n" "$table" "$f"
+  done
+  echo "COMMIT;"
+} | psql "$PGURI"
+``` 
 
 ---
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -359,7 +359,6 @@ done
 
 Load parent tables before child tables to satisfy foreign-key constraints.
 
-
 ```bash
 {
   echo "BEGIN;"
@@ -370,7 +369,7 @@ Load parent tables before child tables to satisfy foreign-key constraints.
   done
   echo "COMMIT;"
 } | psql "$PGURI"
-``` 
+```
 
 ---
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the export process, focusing on making SQL schema resolution more robust and export output more organized and user-friendly. The changes ensure that SQL schemas are matched to collections using sanitized names, improve namespace handling, and adjust the export layout to be database-scoped. Additionally, the export process now prints the resolved output path for each exported table, providing clearer feedback to users.

**Export schema resolution and namespace handling:**

* SQL schemas are now resolved by sanitized collection name only: MongoDB collection names remain raw for querying, but schema lookup uses the lowercased, sanitized filename (e.g., `listingsAndReviews` → `listingsandreviews.sql`), fixing mixed-case collection/export mismatches. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-R33) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR876-R935) [[3]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL485-R496) [[4]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL517-R517)
* The `export --namespace` argument now consistently overrides the config namespace, and export reads SQL from `schema/tables/<db_name>/` with no fallback to older flat locations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-R33) [[2]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bR228-R234) [[3]](diffhunk://#diff-3af2a6883fb49e4380929b60fb0634cb489a32b12266fa0b157df222e3cc843bL849-R864)

**Export output and feedback improvements:**

* Export output layout is now database-scoped: generated `.csv.gz` files are written under `data/<database_name>/<sanitized_collection_name>/` for improved organization. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-R33) [[2]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL535-L541)
* Export output now prints the resolved `.csv.gz` path for each table, logging row counts alongside the final file location during export. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-R33) [[2]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL566-R568)

**Documentation update:**

* The tutorial has been updated to reflect the new export structure and includes example commands for creating tables and loading data using the new layout.