### PR TITLE
feat (conf file): add exclude/include parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
----
+### Changed
+
+- **Config file**: Added `include` and `exclude` parameters to the `[source]` section in TOML config files. These allow users to specify which collections to include or exclude during inference, export, and import steps. The `exclude` list takes precedence over `include` if both are specified.
+- **Primary key and foreign key handling**: Now supports multi-column primary keys and corresponding foreign key relationships throughout the export and import logic. The internal representation and SQL generation have been updated to handle composite keys, and row extraction logic now correctly maps MongoDB `_id` fields to the appropriate SQL columns, including flattened object ID fields for composite PKs.
+- **Type inference**: Simplified type inference for number fields, mapping MongoDB `ObjectId` to `TEXT` instead of `UUID`, and ensuring numeric strings remain `TEXT`.
+- **Analyzer**: Empty arrays no longer count as present for probability calculations.
+- **CLI**: `to-pg`, `infer`, `export`, and `import` commands now honor the `include` and `exclude` config parameters for collection filtering.
+- **Tests**: Added comprehensive tests for multi-column PKs, collection filtering, and row extraction logic.
+
+### Fixed
+
+- **Composite PKs**: Fixed bugs in row extraction and SQL generation for tables with composite primary keys.
+- **Collection filtering**: Fixed issues where excluded collections could still be processed.
+- **Error reporting**: Improved error messages for missing SQL schemas and import/export failures, including line-level details for CSV import errors.
+- **Child tables**: Child tables now drop redundant nested `id` fields instead of renaming them.
+- **Post-import report**: Now filters collections using sanitized names and honors `include`/`exclude` lists.
 
 ## [0.4.0] - 2026-05-25
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -183,6 +183,10 @@ impl FieldAcc {
     }
 
     fn observe_value(&mut self, bson: &Bson) {
+        if matches!(bson, Bson::Array(arr) if arr.is_empty()) {
+            return;
+        }
+
         self.count += 1;
         let type_name = bson_type_name(bson);
         let acc = self
@@ -542,5 +546,40 @@ pub fn bson_to_json_value(bson: &Bson) -> Option<serde_json::Value> {
             Some(serde_json::Value::Array(vals))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Analyzer;
+    use bson::doc;
+
+    #[test]
+    fn empty_arrays_do_not_count_as_present_for_probability() {
+        let docs = vec![
+            doc! { "advices": [] },
+            doc! { "advices": [ { "advice": "keep" } ] },
+            doc! { "advices": [ { "advice": "check" } ] },
+        ];
+
+        let mut analyzer = Analyzer::new(true);
+        for doc in &docs {
+            analyzer.process_document(doc);
+        }
+        let schema = analyzer.finish();
+
+        let advices = schema
+            .object
+            .get("advices")
+            .expect("advices field should exist");
+        assert!(
+            (advices.probability - (2.0 / 3.0)).abs() < f64::EPSILON,
+            "empty arrays should not count as present"
+        );
+        let array_type = advices
+            .types
+            .get("Array")
+            .expect("advices should be typed as array");
+        assert_eq!(array_type.sampled, 2);
     }
 }

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -497,6 +497,8 @@ async fn run_infer(args: InferArgs) -> Result<()> {
         conf_number,
         conf_percent,
         conf_jsonb,
+        conf_include,
+        conf_exclude,
     ) = if let Some(ref conf) = args.config {
         let c = read_conf(conf)?;
         let source_uri = args.mongo.source_uri.clone().or(c.source_uri).ok_or_else(|| {
@@ -515,13 +517,24 @@ async fn run_infer(args: InferArgs) -> Result<()> {
             c.number,
             c.percent,
             c.jsonb,
+            c.include,
+            c.exclude,
         )
     } else {
         let source_uri =
             args.mongo.source_uri.clone().ok_or_else(|| {
                 anyhow!("No SOURCE_URI provided: pass --source-uri or -c <config>")
             })?;
-        (source_uri, args.output_dir.clone(), None, None, None, false)
+        (
+            source_uri,
+            args.output_dir.clone(),
+            None,
+            None,
+            None,
+            false,
+            Vec::new(),
+            Vec::new(),
+        )
     };
 
     let namespace = args.namespace.clone().or(conf_namespace);
@@ -552,7 +565,7 @@ async fn run_infer(args: InferArgs) -> Result<()> {
     match namespace {
         None => {
             // No namespace provided: enumerate all user databases and infer each.
-            infer_all_databases(&client, &args, !quiet_infer).await?;
+            infer_all_databases(&client, &args, &conf_include, &conf_exclude, !quiet_infer).await?;
         }
         Some(ref ns) if ns.contains('.') => {
             // Single collection: <db>.<collection>
@@ -577,6 +590,12 @@ async fn run_infer(args: InferArgs) -> Result<()> {
                     "Warning: collection '{coll_name}' does not exist in database '{db_name}'. Available collections: {}",
                     existing_colls.join(", ")
                 );
+            }
+            if !should_infer_collection(coll_name, &conf_include, &conf_exclude) {
+                eprintln!(
+                    "Skipping {db_name}.{coll_name}: filtered out by source.include/source.exclude"
+                );
+                return Ok(());
             }
             let schema = infer_collection(
                 &client,
@@ -612,7 +631,11 @@ async fn run_infer(args: InferArgs) -> Result<()> {
                 .context("Failed to list collections")?;
 
             let mut all_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
-            for coll_name in coll_names.iter().filter(|n| !n.starts_with("system.")) {
+            for coll_name in coll_names
+                .iter()
+                .filter(|n| !n.starts_with("system."))
+                .filter(|n| should_infer_collection(n, &conf_include, &conf_exclude))
+            {
                 match infer_collection(
                     &client,
                     db_name,
@@ -760,7 +783,13 @@ fn print_infer_summary(conf: &Path) -> Result<()> {
 ///
 /// Output files are written as `<output_dir>/<dbname>/<collname>/`.
 /// Report generation is handled separately by the `report` command.
-async fn infer_all_databases(client: &Client, args: &InferArgs, emit_stats: bool) -> Result<()> {
+async fn infer_all_databases(
+    client: &Client,
+    args: &InferArgs,
+    include: &[String],
+    exclude: &[String],
+    emit_stats: bool,
+) -> Result<()> {
     let all_dbs = client
         .list_database_names()
         .await
@@ -796,7 +825,11 @@ async fn infer_all_databases(client: &Client, args: &InferArgs, emit_stats: bool
 
         let mut db_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
 
-        for coll_name in coll_names.iter().filter(|n| !n.starts_with("system.")) {
+        for coll_name in coll_names
+            .iter()
+            .filter(|n| !n.starts_with("system."))
+            .filter(|n| should_infer_collection(n, include, exclude))
+        {
             let db_out_dir = args.output_dir.as_deref().map(|d| d.join(db_name));
             match infer_collection(
                 client,
@@ -1230,7 +1263,7 @@ fn run_init(args: InitArgs) -> Result<()> {
         .map(|ns| ns.split('.').next().unwrap_or(ns))
         .unwrap_or(&args.project_name);
     let conf_content = format!(
-        "[project]\nbase_dir = \"{}\"\nproject_dir = \"{}\"\n\n[source]\nuri = {}\nnamespace = {}\nnumber = 1000\n# percent = 10.0\njsonb = false\n\n[target]\nuri = {}\ndatabase_name = \"{}\"\n",
+        "[project]\nbase_dir = \"{}\"\nproject_dir = \"{}\"\n\n[source]\nuri = {}\nnamespace = {}\nnumber = 1000\n# percent = 10.0\njsonb = false\n# include = [\"collection_a\", \"collection_b\"]\n# exclude = [\"collection_to_skip\"]\n\n[target]\nuri = {}\ndatabase_name = \"{}\"\n",
         args.project_base.display(),
         args.project_name,
         args.source_uri
@@ -1909,6 +1942,8 @@ struct ConfData {
     number: Option<u64>,
     percent: Option<f64>,
     jsonb: bool,
+    include: Vec<String>,
+    exclude: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1933,6 +1968,20 @@ struct TomlSourceSection {
     number: Option<u64>,
     percent: Option<f64>,
     jsonb: Option<bool>,
+    #[serde(default)]
+    include: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+fn should_infer_collection(name: &str, include: &[String], exclude: &[String]) -> bool {
+    if !exclude.is_empty() {
+        !exclude.iter().any(|candidate| candidate == name)
+    } else if !include.is_empty() {
+        include.iter().any(|candidate| candidate == name)
+    } else {
+        true
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -1959,6 +2008,8 @@ fn read_conf(path: &Path) -> Result<ConfData> {
             number: source.number,
             percent: source.percent,
             jsonb: source.jsonb.unwrap_or(false),
+            include: source.include,
+            exclude: source.exclude,
         })
     }
 
@@ -2020,6 +2071,8 @@ fn read_conf(path: &Path) -> Result<ConfData> {
             number,
             percent,
             jsonb,
+            include: Vec::new(),
+            exclude: Vec::new(),
         })
     }
 
@@ -2485,4 +2538,47 @@ async fn build_post_import_rows(
     }
 
     Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_infer_collection, TomlProjectConfig};
+
+    #[test]
+    fn should_infer_collection_honors_exclude_before_include() {
+        let include = vec!["users".to_owned()];
+        let exclude = vec!["users".to_owned(), "audit".to_owned()];
+
+        assert!(!should_infer_collection("users", &include, &exclude));
+        assert!(should_infer_collection("orders", &include, &exclude));
+    }
+
+    #[test]
+    fn should_infer_collection_honors_include_when_exclude_is_empty() {
+        let include = vec!["users".to_owned(), "orders".to_owned()];
+        let exclude = Vec::new();
+
+        assert!(should_infer_collection("users", &include, &exclude));
+        assert!(!should_infer_collection("audit", &include, &exclude));
+    }
+
+    #[test]
+    fn toml_source_include_and_exclude_are_parsed() {
+        let config: TomlProjectConfig = toml::from_str(
+            r#"
+[project]
+base_dir = "/tmp"
+project_dir = "demo"
+
+[source]
+include = ["users", "orders"]
+exclude = ["audit"]
+"#,
+        )
+        .expect("config should parse");
+
+        let source = config.source.expect("source section should exist");
+        assert_eq!(source.include, vec!["users", "orders"]);
+        assert_eq!(source.exclude, vec!["audit"]);
+    }
 }

--- a/src/bin/mongo2pg.rs
+++ b/src/bin/mongo2pg.rs
@@ -40,6 +40,7 @@ use mongo2pg::to_pg::schema_to_ddl;
 use mongodb::{options::ClientOptions, Client};
 use postgres_native_tls::MakeTlsConnector;
 use serde::{Deserialize, Serialize};
+use strsim::jaro_winkler;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Shared args
@@ -310,7 +311,10 @@ fn run_to_pg(args: ToPgArgs, quiet: bool) -> Result<()> {
     fn prepend_database_preamble(ddl: String, db_name: Option<&str>) -> String {
         match db_name {
             None => ddl,
-            Some(name) => format!("CREATE DATABASE {name};\n\\connect {name}\n\n{ddl}"),
+            Some(name) => {
+                let quoted_name = quote_ident(name);
+                format!("CREATE DATABASE {quoted_name};\n\\connect {quoted_name}\n\n{ddl}")
+            }
         }
     }
 
@@ -319,6 +323,12 @@ fn run_to_pg(args: ToPgArgs, quiet: bool) -> Result<()> {
         let c = read_conf(conf)?;
         c.namespace
             .map(|namespace| split_namespace_scope(&namespace).0.to_owned())
+    } else {
+        None
+    };
+
+    let config_target_schema: Option<String> = if let Some(ref conf) = args.config {
+        read_conf(conf)?.target_schema
     } else {
         None
     };
@@ -452,7 +462,10 @@ fn run_to_pg(args: ToPgArgs, quiet: bool) -> Result<()> {
         let ddl = schema_to_ddl(
             &schema,
             table_name,
-            args.schema.as_deref().or(Some(table_name)),
+            args.schema
+                .as_deref()
+                .or(config_target_schema.as_deref())
+                .or(Some(table_name)),
         );
         let db_name = rel_sql
             .parent()
@@ -604,6 +617,7 @@ async fn run_infer(args: InferArgs) -> Result<()> {
                 coll_name,
                 &args,
                 None,
+                Some((1, 1)),
                 !quiet_infer,
             )
             .await?;
@@ -629,13 +643,15 @@ async fn run_infer(args: InferArgs) -> Result<()> {
                 .list_collection_names()
                 .await
                 .context("Failed to list collections")?;
-
-            let mut all_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
-            for coll_name in coll_names
+            let filtered_coll_names: Vec<&String> = coll_names
                 .iter()
                 .filter(|n| !n.starts_with("system."))
                 .filter(|n| should_infer_collection(n, &conf_include, &conf_exclude))
-            {
+                .collect();
+            let total_collections = filtered_coll_names.len();
+
+            let mut all_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
+            for (index, coll_name) in filtered_coll_names.iter().enumerate() {
                 match infer_collection(
                     &client,
                     db_name,
@@ -643,12 +659,13 @@ async fn run_infer(args: InferArgs) -> Result<()> {
                     coll_name,
                     &args,
                     None,
+                    Some((index + 1, total_collections)),
                     !quiet_infer,
                 )
                 .await
                 {
                     Ok(schema) => {
-                        all_schemas.insert(coll_name.clone(), schema);
+                        all_schemas.insert((*coll_name).clone(), schema);
                     }
                     Err(e) => eprintln!("  [warn] skipping {db_name}.{coll_name}: {e:#}"),
                 }
@@ -811,6 +828,8 @@ async fn infer_all_databases(
         user_dbs.join(", ")
     );
 
+    let mut databases_with_collections: Vec<(String, Vec<String>)> = Vec::new();
+
     for db_name in &user_dbs {
         let db = client.database(db_name);
         let coll_names = match db.list_collection_names().await {
@@ -823,13 +842,27 @@ async fn infer_all_databases(
             }
         };
 
-        let mut db_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
-
-        for coll_name in coll_names
-            .iter()
+        let filtered_coll_names: Vec<String> = coll_names
+            .into_iter()
             .filter(|n| !n.starts_with("system."))
             .filter(|n| should_infer_collection(n, include, exclude))
-        {
+            .collect();
+
+        databases_with_collections.push((db_name.clone(), filtered_coll_names));
+    }
+
+    let total_collections: usize = databases_with_collections
+        .iter()
+        .map(|(_, coll_names)| coll_names.len())
+        .sum();
+
+    let mut current_collection = 0usize;
+
+    for (db_name, coll_names) in &databases_with_collections {
+        let mut db_schemas: IndexMap<String, CollectionSchema> = IndexMap::new();
+
+        for coll_name in coll_names {
+            current_collection += 1;
             let db_out_dir = args.output_dir.as_deref().map(|d| d.join(db_name));
             match infer_collection(
                 client,
@@ -838,6 +871,7 @@ async fn infer_all_databases(
                 coll_name,
                 args,
                 db_out_dir.as_deref(),
+                Some((current_collection, total_collections)),
                 emit_stats,
             )
             .await
@@ -875,13 +909,17 @@ async fn infer_collection(
     output_name: &str,
     args: &InferArgs,
     output_dir_override: Option<&Path>,
+    progress: Option<(usize, usize)>,
     emit_stats: bool,
 ) -> Result<CollectionSchema> {
+    let collection_label = format!("{db_name}.{coll_name}");
+    let progress_prefix = progress.map(|(current, total)| format!("[{current}/{total}] "));
+
     let output_dir = output_dir_override.or(args.output_dir.as_deref());
     let db = client.database(db_name);
     let collection = db.collection::<bson::Document>(coll_name);
 
-    let (sample_size, known_total) = if let Some(pct) = args.percent {
+    let (sample_size, known_total, sample_basis) = if let Some(pct) = args.percent {
         if pct <= 0.0 || pct > 100.0 {
             return Err(anyhow!(
                 "--percent must be between 0 (exclusive) and 100 (inclusive), got {pct}"
@@ -892,9 +930,20 @@ async fn infer_collection(
             .await
             .context("Failed to get document count for --percent calculation")?;
         let n = ((total as f64 * pct / 100.0).ceil() as u64).max(1);
-        (n, Some(total))
+        (
+            n,
+            Some(total),
+            format!("sample: --percent {pct}% => {n}/{total} docs"),
+        )
     } else {
-        (args.number.unwrap_or(1000), None)
+        let n = args.number.unwrap_or(1000);
+        (n, None, format!("sample: --number {n} docs"))
+    };
+
+    if let Some(prefix) = &progress_prefix {
+        eprintln!("{prefix}Inferring {collection_label} ({sample_basis})");
+    } else {
+        eprintln!("Inferring {collection_label} ({sample_basis})");
     };
 
     let mut analyzer = Analyzer::new(true);
@@ -991,7 +1040,11 @@ async fn infer_collection(
     if emit_stats {
         let stderr = io::stderr();
         let mut handle = stderr.lock();
-        writeln!(handle, "[{db_name}.{coll_name}]")?;
+        if let Some(prefix) = &progress_prefix {
+            writeln!(handle, "{prefix}{collection_label} ({sample_basis})")?;
+        } else {
+            writeln!(handle, "[{collection_label}] ({sample_basis})")?;
+        }
         for line in &stats_lines {
             writeln!(handle, "{line}")?;
         }
@@ -1309,6 +1362,8 @@ async fn run_export(args: ExportArgs) -> Result<()> {
         .ok_or_else(|| anyhow!("Provide -c <config>"))?;
 
     let c = read_conf(conf)?;
+    let conf_include = c.include.clone();
+    let conf_exclude = c.exclude.clone();
     let source_uri = args
         .mongo
         .source_uri
@@ -1348,6 +1403,34 @@ async fn run_export(args: ExportArgs) -> Result<()> {
         s.to_lowercase()
     }
 
+    fn warn_missing_sql_schema(
+        coll_name: &str,
+        sanitized: &str,
+        tables_dir: &Path,
+        sql_files: &[(String, String)],
+    ) {
+        let expected_path = tables_dir.join(format!("{sanitized}.sql"));
+        let closest_existing = sql_files
+            .iter()
+            .map(|(stem, sanitized_stem)| (stem, jaro_winkler(sanitized, sanitized_stem)))
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+            .filter(|(_, score)| *score >= 0.88)
+            .map(|(stem, _)| tables_dir.join(format!("{stem}.sql")));
+
+        if let Some(closest_path) = closest_existing {
+            eprintln!(
+                "  warning: SQL schema not found for collection '{coll_name}': expected {}, closest existing file is {}",
+                expected_path.display(),
+                closest_path.display()
+            );
+        } else {
+            eprintln!(
+                "  warning: SQL schema not found for collection '{coll_name}': expected {} – run `to-pg` first",
+                expected_path.display()
+            );
+        }
+    }
+
     let collections: Vec<String> = if let Some(name) = args.collection.clone() {
         // If a specific collection is requested, check for its sanitized .sql file
         let sanitized = sanitize(&name);
@@ -1381,7 +1464,13 @@ async fn run_export(args: ExportArgs) -> Result<()> {
         let sql_set: HashSet<String> = sql_files.iter().map(|(_, s)| s.clone()).collect();
 
         // Get all collection names from MongoDB
-        let mongo_colls = client.database(&db_name).list_collection_names().await?;
+        let mongo_colls = client
+            .database(&db_name)
+            .list_collection_names()
+            .await?
+            .into_iter()
+            .filter(|coll| !coll.starts_with("system."))
+            .filter(|coll| should_infer_collection(coll, &conf_include, &conf_exclude));
 
         // For each collection, if its sanitized name matches a sanitized .sql file, export it
         let mut matched = Vec::new();
@@ -1391,10 +1480,7 @@ async fn run_export(args: ExportArgs) -> Result<()> {
             if sql_set.contains(&sanitized) && sql_path.exists() {
                 matched.push(coll);
             } else {
-                eprintln!(
-                    "  warning: SQL schema not found: {} – run `to-pg` first",
-                    sql_path.display()
-                );
+                warn_missing_sql_schema(&coll, &sanitized, &tables_dir, &sql_files);
             }
         }
         matched.sort();
@@ -1406,8 +1492,14 @@ async fn run_export(args: ExportArgs) -> Result<()> {
         return Ok(());
     }
 
-    for coll_name in &collections {
-        eprintln!("[{db_name}.{coll_name}]");
+    let total_collections = collections.len();
+
+    for (index, coll_name) in collections.iter().enumerate() {
+        eprintln!(
+            "[{}/{}] Exporting {db_name}.{coll_name}",
+            index + 1,
+            total_collections
+        );
         match export_collection(&client, &db_name, coll_name, &tables_dir, &data_dir).await {
             Ok(()) => {}
             Err(e) => eprintln!("  warning: {e}"),
@@ -1419,6 +1511,9 @@ async fn run_export(args: ExportArgs) -> Result<()> {
 
 async fn run_import(args: ImportArgs) -> Result<()> {
     let c = read_conf(&args.config)?;
+    let conf_include: Vec<String> = c.include.iter().map(|name| sanitize_name(name)).collect();
+    let conf_exclude: Vec<String> = c.exclude.iter().map(|name| sanitize_name(name)).collect();
+    let target_schema = c.target_schema.clone();
     let target_uri = c
         .target_uri
         .clone()
@@ -1434,6 +1529,8 @@ async fn run_import(args: ImportArgs) -> Result<()> {
     let target_database_name = c.target_database_name.as_deref().unwrap_or(db_name);
     let requested_collection = args.collection.as_deref().or(namespace_collection);
     let requested_collection_dir = requested_collection.map(sanitize_name);
+    let should_import_collection =
+        |name: &str| should_infer_collection(name, &conf_include, &conf_exclude);
 
     let project_root = c.base_dir.join(&c.project_dir);
     let tables_root = project_root.join("schema").join("tables");
@@ -1480,6 +1577,12 @@ async fn run_import(args: ImportArgs) -> Result<()> {
                     path.file_stem().and_then(|stem| stem.to_str()) == Some(collection_dir)
                 })
         })
+        .filter(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(&should_import_collection)
+                .unwrap_or(false)
+        })
         .collect();
     sql_files.sort();
 
@@ -1487,12 +1590,18 @@ async fn run_import(args: ImportArgs) -> Result<()> {
         return Err(anyhow!("No SQL files found in {}", tables_dir.display()));
     }
 
+    use std::collections::HashSet;
+    let mut allowed_table_names: HashSet<String> = HashSet::new();
+
     for sql_path in &sql_files {
         let sql = std::fs::read_to_string(sql_path)
             .with_context(|| format!("Failed to read {}", sql_path.display()))?;
         let executable_sql = strip_psql_preamble(&sql);
         if executable_sql.trim().is_empty() {
             continue;
+        }
+        for table in parse_sql(&executable_sql) {
+            allowed_table_names.insert(table.name);
         }
         pg_client
             .batch_execute(&executable_sql)
@@ -1513,12 +1622,25 @@ async fn run_import(args: ImportArgs) -> Result<()> {
                     path.file_name().and_then(|name| name.to_str()) == Some(collection_dir)
                 })
         })
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(&should_import_collection)
+                .unwrap_or(false)
+        })
         .flat_map(|collection_dir| {
             std::fs::read_dir(&collection_dir)
                 .into_iter()
                 .flat_map(|entries| entries.filter_map(|entry| entry.ok()))
                 .map(|entry| entry.path())
                 .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("gz"))
+                .filter(|path| {
+                    path.file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .and_then(|stem| stem.strip_suffix(".csv"))
+                        .map(|table_name| allowed_table_names.contains(table_name))
+                        .unwrap_or(false)
+                })
                 .collect::<Vec<_>>()
         })
         .collect();
@@ -1537,10 +1659,14 @@ async fn run_import(args: ImportArgs) -> Result<()> {
         .await?;
 
     for csv_path in &csv_files {
-        let schema = csv_path
-            .parent()
-            .and_then(|path| path.file_name())
-            .and_then(|name| name.to_str())
+        let schema = target_schema
+            .as_deref()
+            .or_else(|| {
+                csv_path
+                    .parent()
+                    .and_then(|path| path.file_name())
+                    .and_then(|name| name.to_str())
+            })
             .ok_or_else(|| anyhow!("Cannot derive schema name from {}", csv_path.display()))?;
         let table = csv_path
             .file_stem()
@@ -1552,17 +1678,28 @@ async fn run_import(args: ImportArgs) -> Result<()> {
             quote_ident(schema),
             quote_ident(table)
         );
-        transaction
-            .batch_execute(&truncate_sql)
-            .await
-            .with_context(|| format!("Failed to truncate {}.{}", schema, table))?;
+        match transaction.batch_execute(&truncate_sql).await {
+            Ok(()) => {}
+            Err(err) => {
+                return Err(anyhow!(
+                    "Failed to truncate {}.{}\n{}",
+                    schema,
+                    table,
+                    format_postgres_error(&err)
+                ));
+            }
+        }
     }
 
     for csv_path in &csv_files {
-        let schema = csv_path
-            .parent()
-            .and_then(|path| path.file_name())
-            .and_then(|name| name.to_str())
+        let schema = target_schema
+            .as_deref()
+            .or_else(|| {
+                csv_path
+                    .parent()
+                    .and_then(|path| path.file_name())
+                    .and_then(|name| name.to_str())
+            })
             .ok_or_else(|| anyhow!("Cannot derive schema name from {}", csv_path.display()))?;
         let table = csv_path
             .file_stem()
@@ -1580,21 +1717,44 @@ async fn run_import(args: ImportArgs) -> Result<()> {
         let mut contents = Vec::new();
         std::io::Read::read_to_end(&mut decoder, &mut contents)
             .with_context(|| format!("Failed to decompress {}", csv_path.display()))?;
+        let content_text = String::from_utf8_lossy(&contents).into_owned();
 
-        let sink = transaction
-            .copy_in(&copy_sql)
-            .await
-            .with_context(|| format!("Failed to start COPY for {}.{}", schema, table))?;
+        let sink = match transaction.copy_in(&copy_sql).await {
+            Ok(sink) => sink,
+            Err(err) => {
+                return Err(anyhow!(
+                    "Failed to start COPY for {}.{}\n{}",
+                    schema,
+                    table,
+                    format_postgres_error(&err)
+                ));
+            }
+        };
         let mut sink = pin!(sink);
         sink.as_mut()
             .send(Bytes::from(contents))
             .await
             .with_context(|| format!("Failed to stream CSV data for {}", csv_path.display()))?;
-        let rows = sink
-            .as_mut()
-            .finish()
-            .await
-            .with_context(|| format!("Failed to finish COPY for {}.{}", schema, table))?;
+        let rows = match sink.as_mut().finish().await {
+            Ok(rows) => rows,
+            Err(err) => {
+                let line_detail = extract_copy_error_line(&err)
+                    .and_then(|line_number| {
+                        csv_line_at(&content_text, line_number)
+                            .map(|line| format!("CSV line {line_number}: {line}"))
+                    })
+                    .unwrap_or_default();
+                return Err(anyhow!(
+                    "Failed to finish COPY for {}.{} from {}\n{}{}{}",
+                    schema,
+                    table,
+                    csv_path.display(),
+                    format_postgres_error(&err),
+                    if line_detail.is_empty() { "" } else { "\n" },
+                    line_detail
+                ));
+            }
+        };
         println!(
             "Imported {rows} row(s) into {}.{} from {}",
             schema,
@@ -1809,6 +1969,8 @@ async fn write_post_import_report(
     source_uri_override: &str,
 ) -> Result<()> {
     let c = read_conf(conf)?;
+    let conf_include: Vec<String> = c.include.iter().map(|name| sanitize_name(name)).collect();
+    let conf_exclude: Vec<String> = c.exclude.iter().map(|name| sanitize_name(name)).collect();
     let reports_dir = c.base_dir.join(&c.project_dir).join("reports");
     std::fs::create_dir_all(&reports_dir)
         .with_context(|| format!("Failed to create reports dir {}", reports_dir.display()))?;
@@ -1852,6 +2014,8 @@ async fn write_post_import_report(
             .map(|db_name| pg_uri_with_database(target_uri, db_name))
             .unwrap_or_else(|| target_uri.to_owned()),
         &namespace,
+        &conf_include,
+        &conf_exclude,
         &collections_dir,
         &schema_tables_root,
     )
@@ -1938,6 +2102,7 @@ struct ConfData {
     source_uri: Option<String>,
     target_uri: Option<String>,
     target_database_name: Option<String>,
+    target_schema: Option<String>,
     namespace: Option<String>,
     number: Option<u64>,
     percent: Option<f64>,
@@ -1988,6 +2153,7 @@ fn should_infer_collection(name: &str, include: &[String], exclude: &[String]) -
 struct TomlTargetSection {
     uri: Option<String>,
     database_name: Option<String>,
+    schema: Option<String>,
 }
 
 /// Parse a project config file produced by `mongo2pg init`.
@@ -2004,6 +2170,7 @@ fn read_conf(path: &Path) -> Result<ConfData> {
             source_uri: source.uri,
             target_uri: target.uri,
             target_database_name: target.database_name,
+            target_schema: target.schema,
             namespace: source.namespace,
             number: source.number,
             percent: source.percent,
@@ -2031,6 +2198,7 @@ fn read_conf(path: &Path) -> Result<ConfData> {
         let mut source_uri: Option<String> = None;
         let mut target_uri: Option<String> = None;
         let mut target_database_name: Option<String> = None;
+        let mut target_schema: Option<String> = None;
         let mut namespace: Option<String> = None;
         let mut number: Option<u64> = None;
         let mut percent: Option<f64> = None;
@@ -2045,6 +2213,7 @@ fn read_conf(path: &Path) -> Result<ConfData> {
                     "SOURCE_URI" => source_uri = Some(parsed),
                     "TARGET_URI" => target_uri = Some(parsed),
                     "TARGET_DATABASE_NAME" => target_database_name = Some(parsed),
+                    "TARGET_SCHEMA" => target_schema = Some(parsed),
                     "NAMESPACE" => namespace = Some(parsed),
                     "NUMBER" => number = parsed.parse().ok(),
                     "PERCENT" => percent = parsed.parse().ok(),
@@ -2067,6 +2236,7 @@ fn read_conf(path: &Path) -> Result<ConfData> {
             source_uri,
             target_uri,
             target_database_name,
+            target_schema,
             namespace,
             number,
             percent,
@@ -2125,7 +2295,9 @@ fn strip_psql_preamble(sql: &str) -> String {
     sql.lines()
         .filter(|line| {
             let trimmed = line.trim_start();
-            !trimmed.starts_with("CREATE DATABASE ") && !trimmed.starts_with("\\connect ")
+            !trimmed.starts_with("DROP DATABASE ")
+                && !trimmed.starts_with("CREATE DATABASE ")
+                && !trimmed.starts_with("\\connect ")
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -2143,6 +2315,59 @@ fn pg_uri_with_database(uri: &str, database: &str) -> String {
             format!("{}{database}{}", &base[..=slash], query)
         }
         None => format!("{base}/{database}{query}"),
+    }
+}
+
+fn format_postgres_error(err: &tokio_postgres::Error) -> String {
+    if let Some(db_err) = err.as_db_error() {
+        let mut parts = vec![format!(
+            "{} (SQLSTATE {})",
+            db_err.message(),
+            db_err.code().code()
+        )];
+
+        if let Some(detail) = db_err.detail() {
+            parts.push(format!("DETAIL: {detail}"));
+        }
+        if let Some(context) = db_err.where_() {
+            parts.push(format!("CONTEXT: {context}"));
+        }
+        if let Some(hint) = db_err.hint() {
+            parts.push(format!("HINT: {hint}"));
+        }
+        if let Some(table) = db_err.table() {
+            parts.push(format!("TABLE: {table}"));
+        }
+        if let Some(column) = db_err.column() {
+            parts.push(format!("COLUMN: {column}"));
+        }
+
+        parts.join("\n")
+    } else {
+        err.to_string()
+    }
+}
+
+fn extract_copy_error_line(err: &tokio_postgres::Error) -> Option<usize> {
+    let context = err.as_db_error()?.where_()?;
+    let marker = ", line ";
+    let start = context.find(marker)? + marker.len();
+    let digits: String = context[start..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+fn csv_line_at(contents: &str, line_number: usize) -> Option<&str> {
+    if line_number == 0 {
+        None
+    } else {
+        contents.lines().nth(line_number - 1)
     }
 }
 
@@ -2199,6 +2424,8 @@ async fn build_post_import_rows(
     source_uri: &str,
     target_uri: &str,
     namespace: &str,
+    include: &[String],
+    exclude: &[String],
     collections_root: &Path,
     schema_tables_root: &Path,
 ) -> Result<Vec<PostImportCollectionRow>> {
@@ -2397,6 +2624,7 @@ async fn build_post_import_rows(
         .await
         .with_context(|| format!("Failed to list collections for MongoDB database {db_name}"))?;
     collection_names.retain(|name| !name.starts_with("system."));
+    collection_names.retain(|name| should_infer_collection(&sanitize_name(name), include, exclude));
     if let Some(coll_name) = only_collection {
         collection_names.retain(|name| name == coll_name);
     }
@@ -2542,7 +2770,7 @@ async fn build_post_import_rows(
 
 #[cfg(test)]
 mod tests {
-    use super::{should_infer_collection, TomlProjectConfig};
+    use super::{sanitize_name, should_infer_collection, strip_psql_preamble, TomlProjectConfig};
 
     #[test]
     fn should_infer_collection_honors_exclude_before_include() {
@@ -2563,6 +2791,20 @@ mod tests {
     }
 
     #[test]
+    fn post_import_filters_live_collection_names_using_sanitized_include_exclude() {
+        let include = vec!["activity_feed".to_owned(), "security_logs".to_owned()];
+        let exclude = Vec::new();
+        let live = ["activity-feed", "security_logs", "admin"];
+
+        let kept: Vec<&str> = live
+            .into_iter()
+            .filter(|name| should_infer_collection(&sanitize_name(name), &include, &exclude))
+            .collect();
+
+        assert_eq!(kept, vec!["activity-feed", "security_logs"]);
+    }
+
+    #[test]
     fn toml_source_include_and_exclude_are_parsed() {
         let config: TomlProjectConfig = toml::from_str(
             r#"
@@ -2580,5 +2822,43 @@ exclude = ["audit"]
         let source = config.source.expect("source section should exist");
         assert_eq!(source.include, vec!["users", "orders"]);
         assert_eq!(source.exclude, vec!["audit"]);
+    }
+
+    #[test]
+    fn toml_target_schema_is_parsed() {
+        let config: TomlProjectConfig = toml::from_str(
+            r#"
+[project]
+base_dir = "/tmp"
+project_dir = "demo"
+
+[target]
+schema = "shared_schema"
+"#,
+        )
+        .expect("config should parse");
+
+        let target = config.target.expect("target section should exist");
+        assert_eq!(target.schema.as_deref(), Some("shared_schema"));
+    }
+
+    #[test]
+    fn strip_psql_preamble_removes_drop_create_and_connect() {
+        let sql = r#"
+DROP DATABASE IF EXISTS "demo";
+CREATE DATABASE "demo";
+\connect "demo"
+
+CREATE TABLE demo (
+    id INTEGER PRIMARY KEY
+);
+"#;
+
+        let stripped = strip_psql_preamble(sql);
+
+        assert!(!stripped.contains("DROP DATABASE"));
+        assert!(!stripped.contains("CREATE DATABASE"));
+        assert!(!stripped.contains("\\connect"));
+        assert!(stripped.contains("CREATE TABLE demo"));
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -257,8 +257,8 @@ struct TableNode {
     sql_name: String,
     /// Column names in declaration order (from SQL)
     columns: Vec<String>,
-    /// Primary-key column name (always `"id"`)
-    pk_col: String,
+    /// Primary-key column names in declaration order.
+    pk_cols: Vec<String>,
     /// FK column pointing to the parent table (`None` for root tables)
     fk_col: Option<String>,
     /// MongoDB field name at the current document level that yields this table's data.
@@ -319,12 +319,12 @@ fn build_node(
         None => String::new(),
     };
 
-    let pk_col = sql_t
+    let pk_cols: Vec<String> = sql_t
         .columns
         .iter()
-        .find(|c| c.primary_key)
+        .filter(|c| c.primary_key)
         .map(|c| c.name.clone())
-        .unwrap_or_else(|| "id".to_owned());
+        .collect();
 
     let fk_col = sql_t.foreign_keys.first().map(|fk| fk.from_col.clone());
 
@@ -353,7 +353,7 @@ fn build_node(
     TableNode {
         sql_name: sql_t.name.clone(),
         columns,
-        pk_col,
+        pk_cols,
         fk_col,
         mongo_field,
         is_scalar_array,
@@ -380,6 +380,14 @@ fn find_mongo_field<'a>(doc: &'a bson::Document, sql_col: &str) -> Option<&'a Bs
         }
     }
     None
+}
+
+fn find_root_mongo_field<'a>(doc: &'a bson::Document, sql_col: &str) -> Option<&'a Bson> {
+    find_mongo_field(doc, sql_col).or_else(|| {
+        doc.get_document("_id")
+            .ok()
+            .and_then(|id_doc| find_mongo_field(id_doc, sql_col))
+    })
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -414,12 +422,19 @@ fn extract_rows(
         .columns
         .iter()
         .map(|col| {
-            if col == &node.pk_col {
+            if (!is_root && node.pk_cols.iter().any(|pk| pk == col))
+                || (is_root && node.pk_cols.len() == 1 && node.pk_cols[0] == "id" && col == "id")
+            {
                 Some(my_id.clone())
             } else if Some(col) == node.fk_col.as_ref() {
                 Some(parent_id.unwrap_or("").to_owned())
             } else {
-                find_mongo_field(doc, col)
+                let lookup = if is_root {
+                    find_root_mongo_field(doc, col)
+                } else {
+                    find_mongo_field(doc, col)
+                };
+                lookup
                     .map(|v| {
                         if node.jsonb_cols.contains(col) {
                             Some(serde_json::to_string(&bson_to_json_value(v)).unwrap_or_default())
@@ -450,7 +465,7 @@ fn extract_rows(
                             .columns
                             .iter()
                             .map(|col| {
-                                if col == &child.pk_col {
+                                if child.pk_cols.iter().any(|pk| pk == col) {
                                     Some(child_id.clone())
                                 } else if Some(col) == child.fk_col.as_ref() {
                                     Some(my_id.clone())
@@ -572,4 +587,97 @@ pub async fn export_collection(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_tree, extract_rows};
+    use crate::schema_diagram::parse_sql;
+    use bson::{doc, Bson};
+    use std::collections::HashMap;
+
+    #[test]
+    fn export_root_rows_use_flattened_object_id_fields_and_skip_fake_primary_column() {
+        let sql = r#"
+CREATE TABLE security_logs (
+    log_type TEXT NOT NULL,
+    projectid TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    last_execution TEXT NOT NULL,
+    PRIMARY KEY (log_type, projectid, provider)
+);
+"#;
+
+        let tables = parse_sql(sql);
+        let roots = build_tree(&tables);
+        let mut all_rows = HashMap::new();
+        let mut counters = HashMap::new();
+        let doc = doc! {
+            "_id": {
+                "projectid": "FRAS-P-SAM-FRTERR2",
+                "provider": "atlas",
+                "log_type": "dbAccessHistory"
+            },
+            "last_execution": "2023-07-13T09:02:15.833170"
+        };
+
+        extract_rows(
+            &Bson::Document(doc),
+            &roots[0],
+            None,
+            true,
+            &mut all_rows,
+            &mut counters,
+        );
+
+        let rows = all_rows.get("security_logs").expect("root rows missing");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].len(), 4);
+        assert_eq!(rows[0][0].as_deref(), Some("dbAccessHistory"));
+        assert_eq!(rows[0][1].as_deref(), Some("FRAS-P-SAM-FRTERR2"));
+        assert_eq!(rows[0][2].as_deref(), Some("atlas"));
+        assert_eq!(rows[0][3].as_deref(), Some("2023-07-13T09:02:15.833170"));
+    }
+
+    #[test]
+    fn export_root_rows_write_scalar_id_column_from_mongo_id() {
+        let sql = r#"
+CREATE TABLE activity_feed (
+    id TEXT PRIMARY KEY,
+    activity TEXT NOT NULL,
+    targetid TEXT NOT NULL,
+    targettype TEXT NOT NULL,
+    timestamp DOUBLE PRECISION NOT NULL,
+    who TEXT NOT NULL
+);
+"#;
+
+        let tables = parse_sql(sql);
+        let roots = build_tree(&tables);
+        let mut all_rows = HashMap::new();
+        let mut counters = HashMap::new();
+        let doc = doc! {
+            "_id": "6267ddea9270b5e839a81ac4",
+            "activity": "Project created",
+            "targetid": "FRAS-D-NLX-FEATURE1",
+            "targettype": "project",
+            "timestamp": 1650468505.273496,
+            "who": "me"
+        };
+
+        extract_rows(
+            &Bson::Document(doc),
+            &roots[0],
+            None,
+            true,
+            &mut all_rows,
+            &mut counters,
+        );
+
+        let rows = all_rows.get("activity_feed").expect("root rows missing");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0].as_deref(), Some("6267ddea9270b5e839a81ac4"));
+        assert_eq!(rows[0][1].as_deref(), Some("Project created"));
+        assert_eq!(rows[0][2].as_deref(), Some("FRAS-D-NLX-FEATURE1"));
+    }
 }

--- a/src/schema_diagram.rs
+++ b/src/schema_diagram.rs
@@ -32,6 +32,28 @@ pub struct Table {
     pub foreign_keys: Vec<ForeignKey>,
 }
 
+fn parse_primary_key_columns(line: &str) -> Option<Vec<String>> {
+    let upper = line.to_uppercase();
+    let start = if upper.starts_with("PRIMARY KEY (") {
+        line.find('(')?
+    } else if upper.starts_with("CONSTRAINT ") && upper.contains(" PRIMARY KEY (") {
+        line.find("PRIMARY KEY (")? + "PRIMARY KEY ".len()
+    } else {
+        return None;
+    };
+    let end = line.rfind(')')?;
+    let cols = line[start + 1..end]
+        .split(',')
+        .map(|col| col.trim().to_owned())
+        .filter(|col| !col.is_empty())
+        .collect::<Vec<_>>();
+    if cols.is_empty() {
+        None
+    } else {
+        Some(cols)
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // SQL parser
 // ──────────────────────────────────────────────────────────────────────────────
@@ -55,12 +77,22 @@ pub fn parse_sql(sql: &str) -> Vec<Table> {
         let name = chunk[..paren].trim().to_owned();
         let body = &chunk[paren + 1..close];
 
-        let mut columns = Vec::new();
-        let mut foreign_keys = Vec::new();
+        let mut columns: Vec<Column> = Vec::new();
+        let mut foreign_keys: Vec<ForeignKey> = Vec::new();
 
         for raw_line in body.lines() {
             let line = raw_line.trim().trim_end_matches(',').trim();
             if line.is_empty() {
+                continue;
+            }
+
+            if let Some(pk_cols) = parse_primary_key_columns(line) {
+                for col in &mut columns {
+                    if pk_cols.iter().any(|pk| pk.eq_ignore_ascii_case(&col.name)) {
+                        col.primary_key = true;
+                        col.not_null = true;
+                    }
+                }
                 continue;
             }
 
@@ -112,6 +144,37 @@ pub fn parse_sql(sql: &str) -> Vec<Table> {
     }
 
     tables
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_sql;
+
+    #[test]
+    fn parse_sql_marks_table_level_primary_key_columns_without_fake_primary_column() {
+        let sql = r#"
+CREATE TABLE security_logs (
+    log_type TEXT NOT NULL,
+    projectid TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    last_execution TEXT NOT NULL,
+    PRIMARY KEY (log_type, projectid, provider)
+);
+"#;
+
+        let tables = parse_sql(sql);
+        let table = &tables[0];
+        let cols: Vec<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
+
+        assert_eq!(
+            cols,
+            vec!["log_type", "projectid", "provider", "last_execution"]
+        );
+        assert!(table.columns[0].primary_key);
+        assert!(table.columns[1].primary_key);
+        assert!(table.columns[2].primary_key);
+        assert!(!table.columns[3].primary_key);
+    }
 }
 
 /// Read and parse all `.sql` files in `dir`.

--- a/src/to_pg.rs
+++ b/src/to_pg.rs
@@ -200,36 +200,6 @@ fn all_values_are_whole(values: &[serde_json::Value]) -> bool {
             .all(|v| v.as_f64().is_some_and(|f| f.is_finite() && f == f.floor()))
 }
 
-/// Returns a narrow integer PG type when every sampled value is a numeric string.
-fn numeric_string_pg_type(values: &[serde_json::Value]) -> Option<&'static str> {
-    if values.is_empty() {
-        return None;
-    }
-    if values
-        .iter()
-        .all(|v| v.as_str().is_some_and(|s| s.parse::<i64>().is_ok()))
-    {
-        let max = values
-            .iter()
-            .filter_map(|v| v.as_str().and_then(|s| s.parse::<i64>().ok()))
-            .map(|n| n.unsigned_abs())
-            .max()
-            .unwrap_or(0);
-        return Some(if max <= 2_147_483_647 {
-            "INTEGER"
-        } else {
-            "BIGINT"
-        });
-    }
-    if values
-        .iter()
-        .all(|v| v.as_str().is_some_and(|s| s.parse::<f64>().is_ok()))
-    {
-        return Some("DOUBLE PRECISION");
-    }
-    None
-}
-
 /// Returns `true` when every sampled Date value has a midnight UTC time component,
 /// making it a good candidate for `DATE` rather than `TIMESTAMP WITH TIME ZONE`.
 fn all_dates_are_date_only(values: &[serde_json::Value]) -> bool {
@@ -273,6 +243,7 @@ fn resolve_scalar_pg_type(non_null: &[(&str, &TypeSchema)], col_name: &str) -> S
         let (name, ts) = non_null[0];
         let values = ts.values.as_deref().unwrap_or(&[]);
 
+        // For MongoDB Number fields: if all values are integers, use INTEGER/BIGINT; otherwise, use DOUBLE PRECISION.
         if name == TYPE_NUMBER {
             if all_values_are_whole(values) {
                 let max = values
@@ -286,15 +257,15 @@ fn resolve_scalar_pg_type(non_null: &[(&str, &TypeSchema)], col_name: &str) -> S
                 } else {
                     "BIGINT".to_owned()
                 };
+            } else {
+                // If any value is a decimal, use DOUBLE PRECISION for lossless mapping.
+                return "DOUBLE PRECISION".to_owned();
             }
         }
         if name == TYPE_DATE && all_dates_are_date_only(values) {
             return "DATE".to_owned();
         }
         if name == TYPE_STRING {
-            if let Some(pg) = numeric_string_pg_type(values) {
-                return pg.to_owned();
-            }
             if let Some(pg) = varchar_for_code_field(col_name, values) {
                 return pg;
             }
@@ -324,7 +295,7 @@ fn pk_type_for_id(non_null: &[(&str, &TypeSchema)]) -> String {
     }
     let (name, ts) = non_null[0];
     if name == TYPE_OBJECTID {
-        return "UUID".to_owned();
+        return "TEXT".to_owned();
     }
     if name == TYPE_NUMBER {
         let values = ts.values.as_deref().unwrap_or(&[]);
@@ -373,8 +344,8 @@ pub struct Table {
     name: String,
     columns: Vec<Column>,
     child_tables: Vec<Table>,
-    /// `(fk_column_name, referenced_table_name, referenced_column_name)`
-    parent_ref: Option<(String, String, String)>,
+    /// `[(fk_column_name, referenced_table_name, referenced_column_name)]`
+    parent_ref: Option<Vec<(String, String, String)>>,
 }
 
 impl Table {
@@ -388,14 +359,20 @@ impl Table {
     }
 }
 
-/// Returns `(pk_column_name, pk_pg_type)` for a table, falling back to `("id", "TEXT")`.
-fn find_pk(table: &Table) -> (String, String) {
-    for col in &table.columns {
-        if col.primary_key {
-            return (col.name.clone(), col.pg_type.clone());
-        }
+/// Returns `[(pk_column_name, pk_pg_type)]` for a table, falling back to `[("id", "TEXT")]`.
+fn find_pk_columns(table: &Table) -> Vec<(String, String)> {
+    let pk_columns: Vec<(String, String)> = table
+        .columns
+        .iter()
+        .filter(|col| col.primary_key)
+        .map(|col| (col.name.clone(), col.pg_type.clone()))
+        .collect();
+
+    if pk_columns.is_empty() {
+        vec![("id".to_owned(), "TEXT".to_owned())]
+    } else {
+        pk_columns
     }
-    ("id".to_owned(), "TEXT".to_owned())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -516,8 +493,7 @@ fn add_child_table(
     pg_schema: Option<&str>,
 ) {
     let child_name = child_table_name(&parent.name, array_field_col, pg_schema);
-    let (pk_name, pk_type) = find_pk(parent);
-    let fk_col = format!("{}_id", parent.name);
+    let parent_pks = find_pk_columns(parent);
 
     let mut child = Table::new(child_name);
     child.columns.push(Column {
@@ -526,13 +502,31 @@ fn add_child_table(
         nullable: false,
         primary_key: true,
     });
-    child.columns.push(Column {
-        name: fk_col.clone(),
-        pg_type: fk_scalar_type(&pk_type).to_owned(),
-        nullable: false,
-        primary_key: false,
-    });
-    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    let mut parent_ref = Vec::new();
+    if parent_pks.len() == 1 {
+        let (pk_name, pk_type) = &parent_pks[0];
+        let fk_col = format!("{}_id", parent.name);
+        child.columns.push(Column {
+            name: fk_col.clone(),
+            pg_type: fk_scalar_type(pk_type).to_owned(),
+            nullable: false,
+            primary_key: false,
+        });
+        parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+    } else {
+        for (pk_name, pk_type) in &parent_pks {
+            let fk_col = format!("{}_{}", parent.name, pk_name);
+            child.columns.push(Column {
+                name: fk_col.clone(),
+                pg_type: fk_scalar_type(pk_type).to_owned(),
+                nullable: false,
+                primary_key: false,
+            });
+            parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+        }
+    }
+    child.parent_ref = Some(parent_ref);
 
     process_fields(&mut child, child_fields, "", true, pg_schema);
     parent.child_tables.push(child);
@@ -545,8 +539,7 @@ fn add_scalar_array_table(
     pg_schema: Option<&str>,
 ) {
     let child_name = child_table_name(&parent.name, array_field_col, pg_schema);
-    let (pk_name, pk_type) = find_pk(parent);
-    let fk_col = format!("{}_id", parent.name);
+    let parent_pks = find_pk_columns(parent);
 
     let mut child = Table::new(child_name);
     child.columns.push(Column {
@@ -555,13 +548,31 @@ fn add_scalar_array_table(
         nullable: false,
         primary_key: true,
     });
-    child.columns.push(Column {
-        name: fk_col.clone(),
-        pg_type: fk_scalar_type(&pk_type).to_owned(),
-        nullable: false,
-        primary_key: false,
-    });
-    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    let mut parent_ref = Vec::new();
+    if parent_pks.len() == 1 {
+        let (pk_name, pk_type) = &parent_pks[0];
+        let fk_col = format!("{}_id", parent.name);
+        child.columns.push(Column {
+            name: fk_col.clone(),
+            pg_type: fk_scalar_type(pk_type).to_owned(),
+            nullable: false,
+            primary_key: false,
+        });
+        parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+    } else {
+        for (pk_name, pk_type) in &parent_pks {
+            let fk_col = format!("{}_{}", parent.name, pk_name);
+            child.columns.push(Column {
+                name: fk_col.clone(),
+                pg_type: fk_scalar_type(pk_type).to_owned(),
+                nullable: false,
+                primary_key: false,
+            });
+            parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+        }
+    }
+    child.parent_ref = Some(parent_ref);
 
     let non_null: Vec<(&str, &TypeSchema)> = scalar_types
         .iter()
@@ -591,8 +602,7 @@ fn add_doc_table(
     pg_schema: Option<&str>,
 ) {
     let child_name = child_table_name(&parent.name, doc_field_col, pg_schema);
-    let (pk_name, pk_type) = find_pk(parent);
-    let fk_col = format!("{}_id", parent.name);
+    let parent_pks = find_pk_columns(parent);
 
     let mut child = Table::new(child_name);
     child.columns.push(Column {
@@ -601,13 +611,31 @@ fn add_doc_table(
         nullable: false,
         primary_key: true,
     });
-    child.columns.push(Column {
-        name: fk_col.clone(),
-        pg_type: fk_scalar_type(&pk_type).to_owned(),
-        nullable: false,
-        primary_key: false,
-    });
-    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    let mut parent_ref = Vec::new();
+    if parent_pks.len() == 1 {
+        let (pk_name, pk_type) = &parent_pks[0];
+        let fk_col = format!("{}_id", parent.name);
+        child.columns.push(Column {
+            name: fk_col.clone(),
+            pg_type: fk_scalar_type(pk_type).to_owned(),
+            nullable: false,
+            primary_key: false,
+        });
+        parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+    } else {
+        for (pk_name, pk_type) in &parent_pks {
+            let fk_col = format!("{}_{}", parent.name, pk_name);
+            child.columns.push(Column {
+                name: fk_col.clone(),
+                pg_type: fk_scalar_type(pk_type).to_owned(),
+                nullable: false,
+                primary_key: false,
+            });
+            parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+        }
+    }
+    child.parent_ref = Some(parent_ref);
 
     process_fields(&mut child, doc_fields, "", false, pg_schema);
     parent.child_tables.push(child);
@@ -622,8 +650,7 @@ fn add_map_table(
     pg_schema: Option<&str>,
 ) {
     let child_name = child_table_name(&parent.name, map_field_col, pg_schema);
-    let (pk_name, pk_type) = find_pk(parent);
-    let fk_col = format!("{}_id", parent.name);
+    let parent_pks = find_pk_columns(parent);
 
     let mut child = Table::new(child_name);
     child.columns.push(Column {
@@ -632,13 +659,31 @@ fn add_map_table(
         nullable: false,
         primary_key: true,
     });
-    child.columns.push(Column {
-        name: fk_col.clone(),
-        pg_type: fk_scalar_type(&pk_type).to_owned(),
-        nullable: false,
-        primary_key: false,
-    });
-    child.parent_ref = Some((fk_col, parent.name.clone(), pk_name));
+
+    let mut parent_ref = Vec::new();
+    if parent_pks.len() == 1 {
+        let (pk_name, pk_type) = &parent_pks[0];
+        let fk_col = format!("{}_id", parent.name);
+        child.columns.push(Column {
+            name: fk_col.clone(),
+            pg_type: fk_scalar_type(pk_type).to_owned(),
+            nullable: false,
+            primary_key: false,
+        });
+        parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+    } else {
+        for (pk_name, pk_type) in &parent_pks {
+            let fk_col = format!("{}_{}", parent.name, pk_name);
+            child.columns.push(Column {
+                name: fk_col.clone(),
+                pg_type: fk_scalar_type(pk_type).to_owned(),
+                nullable: false,
+                primary_key: false,
+            });
+            parent_ref.push((fk_col, parent.name.clone(), pk_name.clone()));
+        }
+    }
+    child.parent_ref = Some(parent_ref);
 
     // Use UUID type if all keys are UUIDs, else TEXT
     let key_type = if value_fields.keys().all(|k| is_uuid_keyed_name(k)) {
@@ -691,6 +736,51 @@ fn handle_array_field(
     }
 }
 
+fn flatten_object_id_fields(
+    table: &mut Table,
+    fields: &IndexMap<String, FieldSchema>,
+    col_prefix: &str,
+) {
+    for (raw_name, field) in fields {
+        let col_name = sanitize(&format!("{col_prefix}{raw_name}"));
+        let non_null: Vec<(&str, &TypeSchema)> = field
+            .types
+            .iter()
+            .filter(|(t, _)| !is_null_type(t.as_str()))
+            .map(|(t, ts)| (t.as_str(), ts))
+            .collect();
+
+        if non_null.is_empty() {
+            continue;
+        }
+
+        if non_null.len() == 1 && non_null[0].0 == TYPE_OBJECT {
+            if let Some(sub_fields) = &non_null[0].1.object {
+                flatten_object_id_fields(table, sub_fields, &format!("{col_name}_"));
+                continue;
+            }
+        }
+
+        let pg_type = if non_null.len() == 1 && non_null[0].0 == TYPE_ARRAY {
+            "JSONB".to_owned()
+        } else if non_null
+            .iter()
+            .any(|(t, _)| *t == TYPE_OBJECT || *t == TYPE_ARRAY)
+        {
+            "JSONB".to_owned()
+        } else {
+            resolve_scalar_pg_type(&non_null, &col_name)
+        };
+
+        table.columns.push(Column {
+            name: col_name,
+            pg_type,
+            nullable: false,
+            primary_key: true,
+        });
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Main recursive field processor
 // ──────────────────────────────────────────────────────────────────────────────
@@ -719,6 +809,20 @@ pub fn process_fields(
         if non_null.is_empty() {
             // Field is always null/undefined – omit from DDL.
             continue;
+        }
+
+        // ── Top-level object _id => flattened composite PK ───────────────────
+
+        if raw_name == "_id"
+            && col_prefix.is_empty()
+            && mark_pk
+            && non_null.len() == 1
+            && non_null[0].0 == TYPE_OBJECT
+        {
+            if let Some(sub_fields) = &non_null[0].1.object {
+                flatten_object_id_fields(table, sub_fields, "");
+                continue;
+            }
         }
 
         // ── Single pure Object ────────────────────────────────────────────────
@@ -840,14 +944,13 @@ pub fn process_fields(
                 primary_key: true,
             });
         } else {
-            // Guard against a literal field named "id" clashing with a surrogate PK.
-            let final_name = if col_name == "id" && table.columns.iter().any(|c| c.name == "id") {
-                "field_id".to_owned()
-            } else {
-                col_name
-            };
+            // Child tables already get a surrogate `id` PK; drop nested scalar `id`
+            // fields instead of duplicating them as `field_id`.
+            if col_name == "id" && table.columns.iter().any(|c| c.name == "id") {
+                continue;
+            }
             table.columns.push(Column {
-                name: final_name,
+                name: col_name,
                 pg_type,
                 nullable,
                 primary_key: false,
@@ -873,10 +976,10 @@ pub fn collect_tables(root: &Table) -> Vec<&Table> {
     result
 }
 
-fn render_column(col: &Column) -> String {
-    let constraint = if col.primary_key {
+fn render_column(col: &Column, inline_primary_key: bool) -> String {
+    let constraint = if col.primary_key && inline_primary_key {
         " PRIMARY KEY"
-    } else if !col.nullable {
+    } else if !col.nullable || col.primary_key {
         " NOT NULL"
     } else {
         ""
@@ -887,10 +990,32 @@ fn render_column(col: &Column) -> String {
 }
 
 fn render_table(table: &Table) -> String {
-    let mut defs: Vec<String> = table.columns.iter().map(render_column).collect();
-    if let Some((fk_col, ref_table, ref_col)) = &table.parent_ref {
+    let pk_columns: Vec<&str> = table
+        .columns
+        .iter()
+        .filter(|col| col.primary_key)
+        .map(|col| col.name.as_str())
+        .collect();
+    let mut defs: Vec<String> = table
+        .columns
+        .iter()
+        .map(|col| render_column(col, pk_columns.len() == 1))
+        .collect();
+    if pk_columns.len() > 1 {
+        defs.push(format!("    PRIMARY KEY ({})", pk_columns.join(", ")));
+    }
+    if let Some(refs) = &table.parent_ref {
+        let fk_cols: Vec<&str> = refs.iter().map(|(fk_col, _, _)| fk_col.as_str()).collect();
+        let ref_table = &refs[0].1;
+        let ref_cols: Vec<&str> = refs
+            .iter()
+            .map(|(_, _, ref_col)| ref_col.as_str())
+            .collect();
         defs.push(format!(
-            "    FOREIGN KEY ({fk_col}) REFERENCES {ref_table} ({ref_col}) DEFERRABLE INITIALLY DEFERRED"
+            "    FOREIGN KEY ({}) REFERENCES {} ({}) DEFERRABLE INITIALLY DEFERRED",
+            fk_cols.join(", "),
+            ref_table,
+            ref_cols.join(", ")
         ));
     }
     let body = defs.join(",\n");
@@ -982,13 +1107,90 @@ mod tests {
     }
 
     #[test]
-    fn test_objectid_pk_becomes_uuid() {
+    fn test_objectid_pk_becomes_text() {
         let docs = vec![doc! { "_id": bson::oid::ObjectId::new(), "x": 1_i32 }];
         let schema = analyze(&docs);
         let ddl = schema_to_ddl(&schema, "t", None);
         assert!(
-            ddl.contains("id UUID PRIMARY KEY"),
-            "ObjectId PK should become UUID"
+            ddl.contains("id TEXT PRIMARY KEY"),
+            "ObjectId PK should become TEXT"
+        );
+    }
+
+    #[test]
+    fn test_numeric_strings_stay_text() {
+        let docs = vec![
+            doc! { "_id": 1_i32, "ldap": "20014291" },
+            doc! { "_id": 2_i32, "ldap": "20101496" },
+        ];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "teams_members", None);
+        assert!(
+            ddl.contains("ldap TEXT NOT NULL"),
+            "Numeric-looking strings should remain TEXT"
+        );
+    }
+
+    #[test]
+    fn test_child_tables_drop_redundant_nested_id_field() {
+        let docs = vec![doc! {
+            "_id": 1_i32,
+            "advices": [{
+                "id": "72a50747b3bfaac0cc2973bf0393ce63fe86c5ed",
+                "advice": "Service has invalid ip range",
+                "object_id": "aiven-pg-pgprepapr",
+                "object_type": "SERVICE"
+            }]
+        }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "advisors", None);
+        assert!(
+            ddl.contains("CREATE TABLE advisors_advices ("),
+            "child table for advices missing"
+        );
+        assert!(
+            !ddl.contains("field_id TEXT"),
+            "nested id field should be dropped instead of renamed"
+        );
+    }
+
+    #[test]
+    fn test_object_id_flattens_into_composite_primary_key() {
+        let docs = vec![doc! {
+            "_id": {
+                "projectid": "FRAS-P-SAM-FRTERR2",
+                "provider": "atlas",
+                "log_type": "dbAccessHistory"
+            },
+            "last_execution": "2023-07-13T09:02:15.833170"
+        }];
+        let schema = analyze(&docs);
+        let ddl = schema_to_ddl(&schema, "executions", None);
+
+        assert!(
+            ddl.contains("projectid TEXT NOT NULL"),
+            "projectid PK column missing"
+        );
+        assert!(
+            ddl.contains("provider TEXT NOT NULL"),
+            "provider PK column missing"
+        );
+        assert!(
+            ddl.contains("log_type TEXT NOT NULL"),
+            "log_type PK column missing"
+        );
+        assert!(
+            ddl.contains("last_execution "),
+            "data field should stay on root table"
+        );
+        assert!(ddl.contains("PRIMARY KEY ("), "composite PK missing");
+        assert!(
+            ddl.contains("log_type") && ddl.contains("projectid") && ddl.contains("provider"),
+            "composite PK should use flattened _id fields"
+        );
+        assert!(
+            !ddl.contains("CREATE TABLE executions__id"),
+            "_id should not become a child table"
         );
     }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of primary keys, foreign keys, and type inference in the codebase, especially for multi-column primary keys and MongoDB-to-Postgres export logic. It also adds comprehensive tests to ensure correctness for these scenarios. The changes enhance support for tables with composite primary keys, improve the mapping of MongoDB IDs, and simplify type inference logic.

**Primary key and foreign key handling:**

* Refactored `TableNode` and related logic in `src/export.rs` to support multiple primary key columns (`pk_cols: Vec<String>`) instead of a single `pk_col`, updating all related usages and row extraction logic to handle composite keys. [[1]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL260-R261) [[2]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL322-R327) [[3]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL356-R356) [[4]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL417-R437) [[5]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cL453-R468)
* Updated `parse_sql` in `src/schema_diagram.rs` to correctly parse and mark table-level (including multi-column) primary keys, removing the need for a fake primary key column. Added a helper function for parsing primary key columns and tests to verify correct marking of PK columns. [[1]](diffhunk://#diff-41ebd53ed352eb47673781c5e9815342e5e440800607bf7d923a1a4a83759d7cR35-R56) [[2]](diffhunk://#diff-41ebd53ed352eb47673781c5e9815342e5e440800607bf7d923a1a4a83759d7cL58-R98) [[3]](diffhunk://#diff-41ebd53ed352eb47673781c5e9815342e5e440800607bf7d923a1a4a83759d7cR149-R179)
* Changed the internal representation of parent references in `src/to_pg.rs` to support multiple foreign key columns (`parent_ref: Option<Vec<(String, String, String)>>`), and updated child table creation logic to generate appropriate foreign key columns for both single and multi-column PKs. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L376-R348) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L391-L398) [[3]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L519-R496) [[4]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R505-R529) [[5]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L548-R542) [[6]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R551-R575)

**MongoDB to Postgres export improvements:**

* Enhanced row extraction logic to correctly map MongoDB `_id` fields to the appropriate SQL columns, including handling of flattened object ID fields for composite PKs, and added tests to verify correct row extraction for both composite and scalar IDs. [[1]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cR385-R392) [[2]](diffhunk://#diff-cbdc42b15472e3166ec85cdce231c85aec30d37d13904422a1bce02c16ca921cR591-R683)

**Type inference and simplification:**

* Simplified type inference in `src/to_pg.rs` by removing the `numeric_string_pg_type` function, and ensuring that number fields are mapped to `INTEGER`, `BIGINT`, or `DOUBLE PRECISION` as appropriate, and mapping MongoDB `ObjectId` to `TEXT` instead of `UUID`. [[1]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L203-L232) [[2]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R246) [[3]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59R260-L297) [[4]](diffhunk://#diff-795bf45442e83067c40cd8026f5c986e83fe7615b6307a16203c279c61515c59L327-R298)

**Analyzer improvements:**

* Modified the analyzer in `src/analyzer.rs` so that empty arrays do not count as present for probability calculations, and added a test to verify this behavior. [[1]](diffhunk://#diff-f1138a93cb7662493e75aa62afc928d68c742aa12a4d0608f5f845604bce4e54R186-R189) [[2]](diffhunk://#diff-f1138a93cb7662493e75aa62afc928d68c742aa12a4d0608f5f845604bce4e54R551-R585)

These changes collectively improve the correctness, flexibility, and maintainability of the codebase, especially for complex database schemas and MongoDB-to-Postgres export scenarios.